### PR TITLE
fix: don't nest empty group keys, better follow slog.Hanlder interface

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -130,11 +130,25 @@ func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
 
 	switch attr.Value.Kind() {
 	case slog.KindGroup:
-		if attr.Key != "" {
-			groupPrefix = groupPrefix + "." + attr.Key
-		}
-		for _, a := range attr.Value.Group() {
-			pairs = appendPair(pairs, groupPrefix, a)
+		attrs := attr.Value.Group()
+		if len(attrs) > 0 {
+			// Only process groups that have non-empty attributes
+			// to properly conform to slog.Handler interface
+			// contract.
+
+			if attr.Key != "" {
+				// If a group's key is empty, attributes should
+				// be inlined to properly conform to
+				// slog.Handler interface contract.
+				if groupPrefix != "" {
+					groupPrefix = groupPrefix + "." + attr.Key
+				} else {
+					groupPrefix = attr.Key
+				}
+			}
+			for _, a := range attrs {
+				pairs = appendPair(pairs, groupPrefix, a)
+			}
 		}
 	default:
 		key := attr.Key


### PR DESCRIPTION
Test snippets to show change:

Before:
```
level=info caller=slogtest.go:97 time=2025-01-14T17:36:28.125642737-05:00 msg=msg a=b .G.c=d e=f
```

After:
```
level=info caller=slogtest.go:97 time=2025-01-14T18:09:01.253906842-05:00 msg=msg a=b G.c=d e=f
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
