### PR TITLE
Ensure slogtests actually run, and fix implementation to meet its expectations

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -74,6 +74,7 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	}
 	pairs = append(pairs, slog.MessageKey, record.Message)
 
+	// preformatted attributes have already had their group prefix applied in WithAttr
 	for _, a := range h.preformatted {
 		pairs = appendPair(pairs, "", a)
 	}
@@ -91,6 +92,7 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	pairs := make([]slog.Attr, 0, len(attrs)+len(h.preformatted))
 	for _, attr := range attrs {
+		// preresolve the group to simplify attr tracking
 		if h.group != "" {
 			attr.Key = h.group + "." + attr.Key
 		}

--- a/handler.go
+++ b/handler.go
@@ -17,7 +17,7 @@ var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
 type GoKitHandler struct {
 	level        slog.Leveler
 	logger       log.Logger
-	preformatted []any
+	preformatted []slog.Attr
 	group        string
 }
 
@@ -70,10 +70,13 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// creation time here.
 	pairs := make([]any, 0, (2 * record.NumAttrs()))
 	if !record.Time.IsZero() {
-		pairs = append(pairs, "time", record.Time)
+		pairs = append(pairs, slog.TimeKey, record.Time)
 	}
-	pairs = append(pairs, "msg", record.Message)
-	pairs = append(pairs, h.preformatted...)
+	pairs = append(pairs, slog.MessageKey, record.Message)
+
+	for _, a := range h.preformatted {
+		pairs = appendPair(pairs, "", a)
+	}
 
 	record.Attrs(func(a slog.Attr) bool {
 		pairs = appendPair(pairs, h.group, a)
@@ -86,9 +89,12 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 // WithAttrs formats the provided attributes and caches them in the handler to
 // attach to all future log calls. It implements slog.Handler.
 func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
-	pairs := make([]any, 0, 2*len(attrs))
-	for _, a := range attrs {
-		pairs = appendPair(pairs, h.group, a)
+	pairs := make([]slog.Attr, 0, len(attrs)+len(h.preformatted))
+	for _, attr := range attrs {
+		if h.group != "" {
+			attr.Key = h.group + "." + attr.Key
+		}
+		pairs = append(pairs, attr)
 	}
 
 	if h.preformatted != nil {
@@ -156,7 +162,7 @@ func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
 			key = groupPrefix + "." + key
 		}
 
-		pairs = append(pairs, key, attr.Value)
+		pairs = append(pairs, key, attr.Value.Resolve())
 	}
 
 	return pairs


### PR DESCRIPTION
Due to an [issue](https://github.com/golang/go/issues/67605) in the `slogtest` package, the `slogtest` implementation would call the `results()` function twice, using the first to validate number of expected logs, and the second would be iterated over and run the check functions. Due to the way the buffer is consumed, the number of expected logs would validate correctly, but then when running checks the second `results()` call would be empty, so none of the checks would actually be executed!

This PR fixes this in test by creating a new reader for the buffer contents without consuming it, and fixes the implementation to meet the expectations of the `slogtest` package. The new reader could be skipped if this package updates to go 1.24, but I was going for a minimal change. 99% of the "fix" is just having the test properly turn a `logfmt` message into the `map[string]any` expected by `slogtest`.