### PR TITLE
ci: use go1.24 for lint/test/release suite

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.0'
+          go-version: '>=1.24.0'
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.0'
+          go-version: '>=1.24.0'
           cache: true
       - name: Go Preflight Tests
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '>=1.23.0'
+          go-version: '>=1.24.0'
           cache: true
       - name: Go Preflight Tests
         run: |


### PR DESCRIPTION
Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
