### PR TITLE
perf: create and cache leveled loggers, don't create ad-hoc

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -28,12 +28,6 @@ type GoKitHandler struct {
 	group        string
 }
 
-func setCaller(logger log.Logger) log.Logger {
-	// Adjust runtime call depth to compensate for the adapter and point to
-	// the appropriate source line.
-	return log.With(logger, "caller", log.Caller(6))
-}
-
 // NewGoKitHandler returns a new slog logger from the provided go-kit
 // logger. Calls to the slog logger are chained to the handler's internal
 // go-kit logger. If provided a level, it will be used to filter log events in
@@ -43,7 +37,9 @@ func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 		logger = defaultGoKitLogger
 	}
 
-	logger = setCaller(logger)
+	// Adjust runtime call depth to compensate for the adapter and point to
+	// the appropriate source line.
+	logger = log.With(logger, "caller", log.Caller(6))
 
 	if level == nil {
 		level = &slog.LevelVar{} // Info level by default.

--- a/handler.go
+++ b/handler.go
@@ -17,8 +17,15 @@ var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
 type GoKitHandler struct {
 	level        slog.Leveler
 	logger       log.Logger
-	preformatted []any // pre-flattened key-value pairs, ready to pass directly to logger.Log()
+	levelLoggers *levelLoggerCache // pre-built leveled loggers
+	preformatted []any             // pre-flattened key-value pairs, ready to pass directly to logger.Log()
 	group        string
+}
+
+func setCaller(logger log.Logger) log.Logger {
+	// Adjust runtime call depth to compensate for the adapter and point to
+	// the appropriate source line.
+	return log.With(logger, "caller", log.Caller(6))
 }
 
 // NewGoKitHandler returns a new slog logger from the provided go-kit
@@ -30,15 +37,17 @@ func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 		logger = defaultGoKitLogger
 	}
 
-	// Adjust runtime call depth to compensate for the adapter and point to
-	// the appropriate source line.
-	logger = log.With(logger, "caller", log.Caller(6))
+	logger = setCaller(logger)
 
 	if level == nil {
 		level = &slog.LevelVar{} // Info level by default.
 	}
 
-	return &GoKitHandler{logger: logger, level: level}
+	return &GoKitHandler{
+		logger:       logger,
+		level:        level,
+		levelLoggers: newLevelCache(logger),
+	}
 }
 
 // Enabled returns true if the internal slog.Leveler is enabled for the
@@ -52,7 +61,7 @@ func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
 // are formatted and added to the log call as individual key/value pairs. It
 // implements slog.Handler.
 func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
-	logger := goKitLevelFunc(h.logger, record.Level)
+	logger := h.levelLoggers.get(record.Level)
 
 	// Pre-compute slice capacity. h.preformatted is already flattened to []any
 	// key-value pairs at WithAttrs time, so len(h.preformatted) is the exact
@@ -104,6 +113,7 @@ func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
+		levelLoggers: h.levelLoggers,
 		preformatted: pairs,
 		group:        h.group,
 	}
@@ -124,6 +134,7 @@ func (h *GoKitHandler) WithGroup(name string) slog.Handler {
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
+		levelLoggers: h.levelLoggers,
 		preformatted: h.preformatted,
 		group:        g,
 	}

--- a/handler.go
+++ b/handler.go
@@ -12,6 +12,12 @@ var _ slog.Handler = (*GoKitHandler)(nil)
 
 var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
 
+// Pay boxing cost once at package init, save 2 heap escapes per Handle() call.
+var (
+	timeKey any = slog.TimeKey
+	msgKey  any = slog.MessageKey
+)
+
 // GoKitHandler implements the slog.Handler interface. It holds an internal
 // go-kit logger that is used to perform the true logging.
 type GoKitHandler struct {
@@ -77,9 +83,9 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	capacity := 4 + len(h.preformatted) + (3 * record.NumAttrs())
 	pairs := make([]any, 0, capacity)
 	if !record.Time.IsZero() {
-		pairs = append(pairs, slog.TimeKey, record.Time)
+		pairs = append(pairs, timeKey, record.Time)
 	}
-	pairs = append(pairs, slog.MessageKey, record.Message)
+	pairs = append(pairs, msgKey, record.Message)
 
 	// Bulk-append pre-flattened attrs, group prefixes were resolved at
 	// WithAttrs() call.

--- a/handler_bench_test.go
+++ b/handler_bench_test.go
@@ -1,6 +1,7 @@
 package sloggokit_test
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -262,4 +263,117 @@ func BenchmarkConcurrentWithAttrsThenLog(b *testing.B) {
 			i++
 		}
 	})
+}
+
+// BenchmarkHandleOnly isolates Handle() with varying amounts of pre-flattened
+// attributes and zero record-level attributes. This highlights the cost of the
+// bulk-append path (append(pairs, h.preformatted...)) without noise from
+// per-attr processing on the record side.
+func BenchmarkHandleOnly(b *testing.B) {
+	preformattedCounts := []int{0, 5, 20}
+
+	for _, n := range preformattedCounts {
+		n := n // Needed because this library supports pre-go1.22
+		b.Run(fmt.Sprintf("Preformatted%d", n), func(b *testing.B) {
+			h := slgk.NewGoKitHandler(log.NewLogfmtLogger(io.Discard), nil)
+			logger := slog.New(h)
+
+			// Build up pre-flattened attrs via With()
+			for i := 0; i < n; i++ {
+				logger = logger.With(
+					slog.String(fmt.Sprintf("pre%d", i), fmt.Sprintf("val%d", i)),
+				)
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				// Log with no record-level attrs -- only the
+				// pre-flattened bulk-append path is exercised.
+				logger.Info("benchmark message")
+			}
+		})
+	}
+}
+
+// BenchmarkEnabledCheck micro-benchmarks the Enabled() guard at matching and
+// non-matching levels. The enabled case adds the overhead of the subsequent
+// Handle() call; the disabled case should be nearly free.
+func BenchmarkEnabledCheck(b *testing.B) {
+	cases := []struct {
+		name     string
+		logLevel slog.Level
+		minLevel slog.Level
+	}{
+		{"Enabled_DebugAtDebug", slog.LevelDebug, slog.LevelDebug},
+		{"Enabled_InfoAtInfo", slog.LevelInfo, slog.LevelInfo},
+		{"Disabled_DebugAtInfo", slog.LevelDebug, slog.LevelInfo},
+		{"Disabled_DebugAtError", slog.LevelDebug, slog.LevelError},
+		{"Disabled_InfoAtWarn", slog.LevelInfo, slog.LevelWarn},
+		{"Disabled_WarnAtError", slog.LevelWarn, slog.LevelError},
+	}
+
+	for _, tc := range cases {
+		tc := tc // Needed because this library supports pre-go1.22
+		b.Run(tc.name, func(b *testing.B) {
+			lvl := &slog.LevelVar{}
+			lvl.Set(tc.minLevel)
+			h := slgk.NewGoKitHandler(log.NewLogfmtLogger(io.Discard), lvl)
+			logger := slog.New(h)
+
+			// Pre-build the method ref to ensure we're comparing
+			// apples to apples across levels.
+			var logFn func(string, ...any)
+			switch tc.logLevel {
+			case slog.LevelDebug:
+				logFn = logger.Debug
+			case slog.LevelInfo:
+				logFn = logger.Info
+			case slog.LevelWarn:
+				logFn = logger.Warn
+			case slog.LevelError:
+				logFn = logger.Error
+			}
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				logFn("benchmark message", "key", "value")
+			}
+		})
+	}
+}
+
+// BenchmarkLevelSelection measures the cost of levelLoggerCache.get() across
+// all four levels. With the level caching optimization, this should show zero
+// allocations (the leveled loggers are pre-built at handler construction time).
+func BenchmarkLevelSelection(b *testing.B) {
+	levels := []struct {
+		name  string
+		level slog.Level
+	}{
+		{"Debug", slog.LevelDebug},
+		{"Info", slog.LevelInfo},
+		{"Warn", slog.LevelWarn},
+		{"Error", slog.LevelError},
+	}
+
+	for _, tc := range levels {
+		tc := tc // Needed because this library supports pre-go1.22
+		b.Run(tc.name, func(b *testing.B) {
+			lvl := &slog.LevelVar{}
+			lvl.Set(tc.level)
+			h := slgk.NewGoKitHandler(log.NewLogfmtLogger(io.Discard), lvl)
+			logger := slog.New(h)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				// Each iteration exercises the full path: Enabled() + Handle()
+				// (including levelLoggers.get()), but with minimal attrs to
+				// isolate level selection cost.
+				logger.Log(context.Background(), tc.level, "msg")
+			}
+		})
+	}
 }

--- a/level.go
+++ b/level.go
@@ -7,17 +7,34 @@ import (
 	"github.com/go-kit/log/level"
 )
 
-func goKitLevelFunc(logger log.Logger, lvl slog.Level) log.Logger {
+// levelLoggerCache holds pre-built leveled loggers so that Handle() can
+// retrieve an existing leveled logger rather than creating a new one each
+// time.
+type levelLoggerCache struct {
+	debugLogger log.Logger
+	infoLogger  log.Logger
+	warnLogger  log.Logger
+	errorLogger log.Logger
+}
+
+func newLevelCache(logger log.Logger) *levelLoggerCache {
+	return &levelLoggerCache{
+		debugLogger: level.Debug(logger),
+		infoLogger:  level.Info(logger),
+		warnLogger:  level.Warn(logger),
+		errorLogger: level.Error(logger),
+	}
+}
+
+func (c *levelLoggerCache) get(lvl slog.Level) log.Logger {
 	switch {
 	case lvl >= slog.LevelError:
-		logger = level.Error(logger)
+		return c.errorLogger
 	case lvl >= slog.LevelWarn:
-		logger = level.Warn(logger)
+		return c.warnLogger
 	case lvl >= slog.LevelInfo:
-		logger = level.Info(logger)
+		return c.infoLogger
 	default:
-		logger = level.Debug(logger)
+		return c.debugLogger
 	}
-
-	return logger
 }

--- a/testmain_test.go
+++ b/testmain_test.go
@@ -1,0 +1,25 @@
+package sloggokit_test
+
+import (
+	"log"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// When SLOGGOKIT_PPROF is set (e.g. ":6060"), start a pprof HTTP server
+	// so that continuous profilers like Parca can scrape the benchmark process
+	// directly.
+	if addr := os.Getenv("SLOGGOKIT_PPROF"); addr != "" {
+		go func() {
+			log.Printf("pprof endpoints available at http://localhost%s/debug/pprof/", addr)
+			if err := http.ListenAndServe(addr, nil); err != nil {
+				log.Printf("pprof server error: %v", err)
+			}
+		}()
+	}
+
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Previously, the helper `goKitLevelFunc` would sit in the hot path of the
Handle() function and for every log call, it would create a new leveled
logger via the appropriate `level.Foo(logger)` calls. Those calls create
a new logger with the the correct level prefix, and that penalty was
paid each log call. Now, when a logger is created or a bare handler is
first used, we pre-create each of the leveled loggers and cache them.
Now when Handle() is called, it only needs to retrieve an existing
logger, not create a new one.

Benchstat with 10 count (benchmark updates coming in next commit):

```
~/go/src/github.com/tjhop/slog-gokit (perf/more-optimizations [  ]) -> benchstat before.benchmark after.benchmark
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │ before.benchmark │           after.benchmark            │
                                      │      sec/op      │    sec/op     vs base                │
BasicLog/NoAttrs-16                         1.953µ ±  1%   2.243µ ±  3%  +14.82% (p=0.000 n=10)
BasicLog/2Attrs-16                          2.323µ ±  2%   2.695µ ±  4%  +16.01% (p=0.000 n=10)
BasicLog/5Attrs-16                          2.848µ ±  2%   3.299µ ±  1%  +15.82% (p=0.000 n=10)
BasicLog/10Attrs-16                         3.700µ ±  2%   4.281µ ±  3%  +15.72% (p=0.000 n=10)
BasicLog/20Attrs-16                         5.409µ ±  1%   6.266µ ±  2%  +15.85% (p=0.000 n=10)
LogLevels/Debug-16                          2.527µ ±  7%   2.535µ ±  3%        ~ (p=0.393 n=10)
LogLevels/Info-16                           2.453µ ±  1%   2.587µ ±  1%   +5.46% (p=0.000 n=10)
LogLevels/Warn-16                           2.496µ ± 11%   2.602µ ±  2%        ~ (p=0.143 n=10)
LogLevels/Error-16                          2.750µ ±  1%   2.588µ ±  1%   -5.89% (p=0.000 n=10)
DisabledLogs-16                             6.454n ±  3%   6.562n ±  3%        ~ (p=0.225 n=10)
WithAttrsChaining/Depth1-16                 2.566µ ±  2%   2.438µ ±  2%   -4.99% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                 2.793µ ±  2%   2.650µ ±  1%   -5.14% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                 2.995µ ±  2%   2.852µ ±  3%   -4.76% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                3.446µ ±  1%   3.310µ ±  1%   -3.98% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                4.314µ ±  2%   4.150µ ±  1%   -3.79% (p=0.001 n=10)
WithGroupNesting/Depth1-16                  2.435µ ±  2%   2.244µ ±  2%   -7.83% (p=0.000 n=10)
WithGroupNesting/Depth3-16                  2.470µ ±  1%   2.282µ ±  2%   -7.61% (p=0.000 n=10)
WithGroupNesting/Depth5-16                  2.508µ ±  1%   2.313µ ±  5%   -7.74% (p=0.000 n=10)
WithGroupNesting/Depth10-16                 2.614µ ±  3%   2.399µ ±  2%   -8.22% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                  3.326µ ±  3%   3.251µ ±  1%   -2.25% (p=0.000 n=10)
AttributeTypes/Strings-16                   2.553µ ±  1%   2.481µ ±  3%   -2.84% (p=0.005 n=10)
AttributeTypes/Ints-16                      2.843µ ±  2%   2.764µ ±  1%   -2.78% (p=0.002 n=10)
AttributeTypes/Mixed-16                     3.082µ ±  3%   2.986µ ±  2%   -3.10% (p=0.001 n=10)
AttributeTypes/LargeStrings-16              4.690µ ±  2%   4.360µ ±  1%   -7.05% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                 3.078µ ±  4%   2.976µ ±  1%   -3.33% (p=0.000 n=10)
AttributeTypes/NestedGroups-16              3.519µ ±  2%   3.393µ ±  3%   -3.57% (p=0.001 n=10)
ConcurrentLogging/Scale1x-16                829.0n ±  3%   746.8n ±  5%   -9.92% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                874.3n ±  4%   796.2n ±  1%   -8.93% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                882.1n ±  2%   819.8n ±  1%   -7.05% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                899.1n ±  2%   842.2n ±  4%   -6.32% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16               874.0n ±  1%   804.8n ± 10%   -7.91% (p=0.015 n=10)
ConcurrentWithAttrsThenLog-16              1034.0n ±  2%   949.1n ±  1%   -8.21% (p=0.000 n=10)
HandleOnly/Preformatted0-16                 2.304µ ±  2%   2.042µ ±  5%  -11.35% (p=0.000 n=10)
HandleOnly/Preformatted5-16                 2.807µ ±  2%   2.584µ ±  6%   -7.93% (p=0.001 n=10)
HandleOnly/Preformatted20-16                4.234µ ±  2%   3.991µ ±  5%   -5.74% (p=0.002 n=10)
EnabledCheck/Enabled_DebugAtDebug-16        2.840µ ±  2%   2.708µ ±  7%   -4.65% (p=0.002 n=10)
EnabledCheck/Enabled_InfoAtInfo-16          2.902µ ±  1%   2.508µ ±  5%  -13.56% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16        36.09n ±  1%   30.13n ±  4%  -16.51% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtError-16       36.34n ±  2%   30.05n ±  1%  -17.31% (p=0.000 n=10)
EnabledCheck/Disabled_InfoAtWarn-16         36.06n ±  1%   30.05n ±  5%  -16.68% (p=0.000 n=10)
EnabledCheck/Disabled_WarnAtError-16        36.51n ±  2%   29.82n ±  2%  -18.32% (p=0.000 n=10)
LevelSelection/Debug-16                     2.193µ ±  2%   1.773µ ±  4%  -19.17% (p=0.000 n=10)
LevelSelection/Info-16                      2.186µ ±  1%   1.766µ ±  2%  -19.19% (p=0.000 n=10)
LevelSelection/Warn-16                      2.194µ ±  3%   1.765µ ±  3%  -19.55% (p=0.000 n=10)
LevelSelection/Error-16                     2.206µ ±  3%   1.746µ ±  1%  -20.85% (p=0.000 n=10)
geomean                                     1.445µ         1.363µ         -5.67%

                                      │ before.benchmark │            after.benchmark             │
                                      │       B/op       │     B/op      vs base                  │
BasicLog/NoAttrs-16                         713.0 ± 0%       568.0 ± 0%  -20.34% (p=0.000 n=10)
BasicLog/2Attrs-16                          953.0 ± 0%       809.0 ± 0%  -15.11% (p=0.000 n=10)
BasicLog/5Attrs-16                        1.299Ki ± 0%     1.157Ki ± 0%  -10.90% (p=0.000 n=10)
BasicLog/10Attrs-16                       2.104Ki ± 0%     1.964Ki ± 0%   -6.68% (p=0.000 n=10)
BasicLog/20Attrs-16                       3.920Ki ± 0%     3.779Ki ± 0%   -3.59% (p=0.000 n=10)
LogLevels/Debug-16                         1017.0 ± 0%       873.0 ± 0%  -14.16% (p=0.000 n=10)
LogLevels/Info-16                          1017.0 ± 0%       873.0 ± 0%  -14.16% (p=0.000 n=10)
LogLevels/Warn-16                          1017.0 ± 0%       873.0 ± 0%  -14.16% (p=0.000 n=10)
LogLevels/Error-16                         1017.0 ± 0%       873.0 ± 0%  -14.16% (p=0.000 n=10)
DisabledLogs-16                             0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                 913.0 ± 0%       769.0 ± 0%  -15.77% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                1041.0 ± 0%       897.0 ± 0%  -13.83% (p=0.000 n=10)
WithAttrsChaining/Depth5-16               1.157Ki ± 0%     1.017Ki ± 0%  -12.15% (p=0.000 n=10)
WithAttrsChaining/Depth10-16              1.471Ki ± 0%     1.330Ki ± 0%   -9.56% (p=0.000 n=10)
WithAttrsChaining/Depth20-16              2.190Ki ± 0%     2.050Ki ± 0%   -6.42% (p=0.000 n=10)
WithGroupNesting/Depth1-16                  865.0 ± 0%       721.0 ± 0%  -16.65% (p=0.000 n=10)
WithGroupNesting/Depth3-16                  873.0 ± 0%       729.0 ± 0%  -16.49% (p=0.000 n=10)
WithGroupNesting/Depth5-16                  897.0 ± 0%       753.0 ± 0%  -16.05% (p=0.000 n=10)
WithGroupNesting/Depth10-16                 929.0 ± 0%       785.0 ± 0%  -15.50% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                1.244Ki ± 0%     1.103Ki ± 0%  -11.38% (p=0.000 n=10)
AttributeTypes/Strings-16                  1088.0 ± 0%       944.0 ± 0%  -13.24% (p=0.000 n=10)
AttributeTypes/Ints-16                     1112.0 ± 0%       968.0 ± 0%  -12.95% (p=0.000 n=10)
AttributeTypes/Mixed-16                   1.228Ki ± 0%     1.086Ki ± 0%  -11.54% (p=0.000 n=10)
AttributeTypes/LargeStrings-16             1001.0 ± 0%       857.0 ± 0%  -14.39% (p=0.000 n=10)
AttributeTypes/GroupAttr-16               1.399Ki ± 0%     1.259Ki ± 0%  -10.05% (p=0.000 n=10)
AttributeTypes/NestedGroups-16            1.720Ki ± 0%     1.579Ki ± 0%   -8.18% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16               1060.0 ± 0%       915.0 ± 0%  -13.68% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16               1060.0 ± 0%       915.0 ± 0%  -13.68% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16               1060.0 ± 0%       915.0 ± 0%  -13.68% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16               1060.0 ± 0%       915.0 ± 0%  -13.68% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16              1059.0 ± 0%       914.0 ± 0%  -13.69% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16             1.308Ki ± 0%     1.167Ki ± 0%  -10.75% (p=0.000 n=10)
HandleOnly/Preformatted0-16                 729.0 ± 0%       585.0 ± 0%  -19.75% (p=0.000 n=10)
HandleOnly/Preformatted5-16                1050.0 ± 0%       905.0 ± 0%  -13.81% (p=0.000 n=10)
HandleOnly/Preformatted20-16              2.152Ki ± 0%     2.012Ki ± 0%   -6.53% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16        881.0 ± 0%       737.0 ± 0%  -16.35% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16          881.0 ± 0%       737.0 ± 0%  -16.35% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16        32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16       32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16         32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16        32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                     728.0 ± 0%       584.0 ± 0%  -19.78% (p=0.000 n=10)
LevelSelection/Info-16                      728.0 ± 0%       584.0 ± 0%  -19.78% (p=0.000 n=10)
LevelSelection/Warn-16                      728.0 ± 0%       584.0 ± 0%  -19.78% (p=0.000 n=10)
LevelSelection/Error-16                     728.0 ± 0%       584.0 ± 0%  -19.78% (p=0.000 n=10)
geomean                                                ²                 -12.37%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │ before.benchmark │           after.benchmark            │
                                      │    allocs/op     │ allocs/op   vs base                  │
BasicLog/NoAttrs-16                        11.000 ± 0%     9.000 ± 0%  -18.18% (p=0.000 n=10)
BasicLog/2Attrs-16                          15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
BasicLog/5Attrs-16                          21.00 ± 0%     19.00 ± 0%   -9.52% (p=0.000 n=10)
BasicLog/10Attrs-16                         32.00 ± 0%     30.00 ± 0%   -6.25% (p=0.000 n=10)
BasicLog/20Attrs-16                         52.00 ± 0%     50.00 ± 0%   -3.85% (p=0.000 n=10)
LogLevels/Debug-16                          16.00 ± 0%     14.00 ± 0%  -12.50% (p=0.000 n=10)
LogLevels/Info-16                           16.00 ± 0%     14.00 ± 0%  -12.50% (p=0.000 n=10)
LogLevels/Warn-16                           16.00 ± 0%     14.00 ± 0%  -12.50% (p=0.000 n=10)
LogLevels/Error-16                          16.00 ± 0%     14.00 ± 0%  -12.50% (p=0.000 n=10)
DisabledLogs-16                             0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                 14.00 ± 0%     12.00 ± 0%  -14.29% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                 14.00 ± 0%     12.00 ± 0%  -14.29% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                 14.00 ± 0%     12.00 ± 0%  -14.29% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                14.00 ± 0%     12.00 ± 0%  -14.29% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                14.00 ± 0%     12.00 ± 0%  -14.29% (p=0.000 n=10)
WithGroupNesting/Depth1-16                  15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
WithGroupNesting/Depth3-16                  15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
WithGroupNesting/Depth5-16                  15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
WithGroupNesting/Depth10-16                 15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                  20.00 ± 0%     18.00 ± 0%  -10.00% (p=0.000 n=10)
AttributeTypes/Strings-16                   18.00 ± 0%     16.00 ± 0%  -11.11% (p=0.000 n=10)
AttributeTypes/Ints-16                      21.00 ± 0%     19.00 ± 0%   -9.52% (p=0.000 n=10)
AttributeTypes/Mixed-16                     26.00 ± 0%     24.00 ± 0%   -7.69% (p=0.000 n=10)
AttributeTypes/LargeStrings-16              18.00 ± 0%     16.00 ± 0%  -11.11% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                 25.00 ± 0%     23.00 ± 0%   -8.00% (p=0.000 n=10)
AttributeTypes/NestedGroups-16              32.00 ± 0%     30.00 ± 0%   -6.25% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16                19.00 ± 0%     17.00 ± 0%  -10.53% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                19.00 ± 0%     17.00 ± 0%  -10.53% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                19.00 ± 0%     17.00 ± 0%  -10.53% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                19.00 ± 0%     16.00 ± 0%  -15.79% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16               18.00 ± 0%     16.00 ± 0%  -11.11% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16               25.00 ± 0%     23.00 ± 0%   -8.00% (p=0.000 n=10)
HandleOnly/Preformatted0-16                 12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
HandleOnly/Preformatted5-16                 12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
HandleOnly/Preformatted20-16                12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16        15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16          15.00 ± 0%     13.00 ± 0%  -13.33% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16        1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16       1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16         1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16        1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                     12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
LevelSelection/Info-16                      12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
LevelSelection/Warn-16                      12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
LevelSelection/Error-16                     12.00 ± 0%     10.00 ± 0%  -16.67% (p=0.000 n=10)
geomean                                                ²               -11.24%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

TLDR:
Initialize and cache leveled loggers at logger creation (or first use
for bare handlers). Pay the allocation cost up front, and not in the hot
path.  Removes 2 allocations from every log call path, at the penalty of
chasing the pointer -- hence the mild performance regression on
extremely basic log benchmarks. In real world usage, loggers are called
to log messages far more often than they're created, so I think it still
makes sense to get this out of the hot path.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
