### PR TITLE
fix: remove lazy init to fix race conditions, require `NewGoKitHandler` constructor

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -44,10 +44,6 @@ func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 // Enabled returns true if the internal slog.Leveler is enabled for the
 // provided log level. It implements slog.Handler.
 func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
-	if h.level == nil {
-		h.level = &slog.LevelVar{} // Info level by default.
-	}
-
 	return level >= h.level.Level()
 }
 
@@ -56,10 +52,6 @@ func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
 // are formatted and added to the log call as individual key/value pairs. It
 // implements slog.Handler.
 func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
-	if h.logger == nil {
-		h.logger = defaultGoKitLogger
-	}
-
 	logger := goKitLevelFunc(h.logger, record.Level)
 
 	// Pre-compute slice capacity. h.preformatted is already flattened to []any

--- a/handler_test.go
+++ b/handler_test.go
@@ -326,3 +326,42 @@ func TestCustomLevelMapping(t *testing.T) {
 		})
 	}
 }
+
+// TestZeroValueHandlerPanics verifies that a zero-value GoKitHandler panics
+// when Enabled or Handle is called, matching the stdlib pattern where
+// slog.JSONHandler and slog.TextHandler also panic when not constructed via
+// their constructors. This documents that NewGoKitHandler is required.
+//
+// WithAttrs and WithGroup don't panic because they only copy fields into a
+// new struct without dereferencing pointers. The resulting child handler
+// will panic when Enabled or Handle is called on it.
+func TestZeroValueHandlerPanics(t *testing.T) {
+	t.Run("Enabled", func(t *testing.T) {
+		h := &slgk.GoKitHandler{}
+		require.Panics(t, func() {
+			h.Enabled(context.Background(), slog.LevelInfo)
+		})
+	})
+	t.Run("Handle", func(t *testing.T) {
+		h := &slgk.GoKitHandler{}
+		require.Panics(t, func() {
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+			_ = h.Handle(context.Background(), record)
+		})
+	})
+	t.Run("WithAttrs_then_Enabled", func(t *testing.T) {
+		h := &slgk.GoKitHandler{}
+		child := h.WithAttrs([]slog.Attr{slog.String("k", "v")})
+		require.Panics(t, func() {
+			child.Enabled(context.Background(), slog.LevelInfo)
+		})
+	})
+	t.Run("WithGroup_then_Handle", func(t *testing.T) {
+		h := &slgk.GoKitHandler{}
+		child := h.WithGroup("g")
+		require.Panics(t, func() {
+			record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
+			_ = child.Handle(context.Background(), record)
+		})
+	})
+}


### PR DESCRIPTION
Remove all lazy nil-guard-then-write paths from `Enabled()` and `Handle()`. The motivation is that this lazy initialization logic is racy. I noticed the issue when reviewing #25.

I've elected to let zero-value `GoKitHandler` panic on use, as it matches the stdlib pattern ([slog.JSONHandler](https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/log/slog/json_handler.go;l=47)/[TextHandler](https://cs.opensource.google/go/go/+/refs/tags/go1.24.2:src/log/slog/text_handler.go;l=45) also panic without their constructors). The alternative would be to serialize lazy initialization through `sync.Once`, but the latter would add overhead to the hot path. I realize that requiring clients to construct through `NewGoKitHandler` is a breaking change, but I think it should be OK as we're on v0.x.

Add `TestZeroValueHandlerPanics` to verify the panic contract for zero-value handlers constructed without `NewGoKitHandler`.