### PR TITLE
perf(handler): resolve caller from slog record, ditch log.Caller()

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"runtime"
+	"strconv"
+	"strings"
 
 	"github.com/go-kit/log"
 )
@@ -12,10 +15,11 @@ var _ slog.Handler = (*GoKitHandler)(nil)
 
 var defaultGoKitLogger = log.NewLogfmtLogger(os.Stderr)
 
-// Pay boxing cost once at package init, save 2 heap escapes per Handle() call.
+// Pay boxing cost once at package init, save 3 heap escapes per Handle() call.
 var (
-	timeKey any = slog.TimeKey
-	msgKey  any = slog.MessageKey
+	timeKey   any = slog.TimeKey
+	msgKey    any = slog.MessageKey
+	callerKey any = "caller"
 )
 
 // GoKitHandler implements the slog.Handler interface. It holds an internal
@@ -32,14 +36,15 @@ type GoKitHandler struct {
 // logger. Calls to the slog logger are chained to the handler's internal
 // go-kit logger. If provided a level, it will be used to filter log events in
 // the handler's Enabled() method.
+//
+// The handler adds a `caller` key to each record, resolved from the program
+// counter that slog captured at the log call site. Records handled directly
+// (without going through an slog.Logger) have no PC set, and thus omit the
+// caller.
 func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 	if logger == nil {
 		logger = defaultGoKitLogger
 	}
-
-	// Adjust runtime call depth to compensate for the adapter and point to
-	// the appropriate source line.
-	logger = log.With(logger, "caller", log.Caller(6))
 
 	if level == nil {
 		level = &slog.LevelVar{} // Info level by default.
@@ -72,12 +77,32 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// buffer for that portion's estimated capacity only.
 	//
 	// We know we need:
+	// - 2 for caller (key + value)
 	// - 2 for timestamp (key + value)
 	// - 2 for message (key + value)
 	// - len(h.preformatted) exact items (pre-flattened, no expansion)
 	// - 2 * record.NumAttrs() for record attrs, +50% buffer for group expansion
-	capacity := 4 + len(h.preformatted) + (3 * record.NumAttrs())
+	capacity := 6 + len(h.preformatted) + (3 * record.NumAttrs())
 	pairs := make([]any, 0, capacity)
+
+	// Resolve the log call site from the PC that slog captured when the
+	// record was created. Cheaper and more accurate to do it here since
+	// it's already captured, vs relying on setting `log.Caller()` depth
+	// and hoping it unwinds correctly.
+	if record.PC != 0 {
+		fs := runtime.CallersFrames([]uintptr{record.PC})
+		f, _ := fs.Next()
+		if f.File != "" {
+			// Trim to basename:line with the same logic as
+			// go-kit's log.Caller:
+			// https://github.com/go-kit/log/blob/v0.2.1/value.go#L84-L93
+			// 
+			// path.Base() would work, opting for direct compatibility.
+			idx := strings.LastIndexByte(f.File, '/')
+			pairs = append(pairs, callerKey, f.File[idx+1:]+":"+strconv.Itoa(f.Line))
+		}
+	}
+
 	if !record.Time.IsZero() {
 		pairs = append(pairs, timeKey, record.Time)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"reflect"
 	"regexp"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -363,5 +365,56 @@ func TestZeroValueHandlerPanics(t *testing.T) {
 			record := slog.NewRecord(time.Now(), slog.LevelInfo, "msg", 0)
 			_ = child.Handle(context.Background(), record)
 		})
+	})
+}
+
+// passthroughHandler forwards records unchanged, simulating slog middleware
+// wrapping the handler. Fixed-depth caller unwinding reports the wrong frame
+// under this wrapping; resolution from record.PC must not.
+type passthroughHandler struct{ next slog.Handler }
+
+func (p passthroughHandler) Enabled(ctx context.Context, l slog.Level) bool {
+	return p.next.Enabled(ctx, l)
+}
+
+func (p passthroughHandler) Handle(ctx context.Context, r slog.Record) error {
+	return p.next.Handle(ctx, r)
+}
+
+func (p passthroughHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return passthroughHandler{next: p.next.WithAttrs(attrs)}
+}
+
+func (p passthroughHandler) WithGroup(name string) slog.Handler {
+	return passthroughHandler{next: p.next.WithGroup(name)}
+}
+
+// TestCaller verifies that the "caller" key is resolved from the record's PC
+// and points at the actual log call site.
+func TestCaller(t *testing.T) {
+	t.Run("direct call site", func(t *testing.T) {
+		var buf bytes.Buffer
+		slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil))
+
+		_, file, line, _ := runtime.Caller(0)
+		slogger.Info("hello") // must stay on the line after the runtime.Caller call
+		require.Contains(t, buf.String(), fmt.Sprintf("caller=%s:%d", filepath.Base(file), line+1))
+	})
+	t.Run("wrapped in middleware handler", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil)
+		slogger := slog.New(passthroughHandler{next: h})
+
+		_, file, line, _ := runtime.Caller(0)
+		slogger.Info("hello") // must stay on the line after the runtime.Caller call
+		require.Contains(t, buf.String(), fmt.Sprintf("caller=%s:%d", filepath.Base(file), line+1))
+	})
+	t.Run("record without PC omits caller", func(t *testing.T) {
+		var buf bytes.Buffer
+		h := slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil)
+
+		record := slog.NewRecord(time.Now(), slog.LevelInfo, "direct handle call", 0)
+		require.NoError(t, h.Handle(context.Background(), record))
+		require.NotContains(t, buf.String(), "caller=")
 	})
 }


### PR DESCRIPTION
Previously we were using log.Caller() to add the source/call site for
us. That had some drawbacks, since it was a Valuer that triggered
re-walking callstack. We also were hard coding the caller depth, which
was fragile. slog already captures the program counter for us, so this
uses it to parse/assign the `caller` kv in the same that go-kit/log
does, for direct compatibility.

benchstat output:
```
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │ ../../../before.benchmark │            after.benchmark            │
                                      │          sec/op           │    sec/op      vs base                │
BasicLog/NoAttrs-16                                  2.369µ ±  4%    1.644µ ±  4%  -30.61% (p=0.000 n=10)
BasicLog/2Attrs-16                                   2.913µ ±  5%    2.075µ ±  4%  -28.74% (p=0.000 n=10)
BasicLog/5Attrs-16                                   3.894µ ± 11%    2.692µ ±  7%  -30.87% (p=0.000 n=10)
BasicLog/10Attrs-16                                  5.709µ ±  4%    3.980µ ±  2%  -30.29% (p=0.000 n=10)
BasicLog/20Attrs-16                                  9.041µ ±  5%    6.230µ ±  2%  -31.09% (p=0.000 n=10)
LogLevels/Debug-16                                   3.237µ ±  5%    2.219µ ±  4%  -31.44% (p=0.000 n=10)
LogLevels/Info-16                                    3.217µ ±  3%    2.275µ ±  3%  -29.27% (p=0.000 n=10)
LogLevels/Warn-16                                    3.226µ ±  3%    2.369µ ±  8%  -26.55% (p=0.000 n=10)
LogLevels/Error-16                                   3.250µ ±  2%    2.289µ ±  6%  -29.57% (p=0.000 n=10)
DisabledLogs-16                                      6.499n ±  7%    6.500n ±  6%        ~ (p=0.796 n=10)
WithAttrsChaining/Depth1-16                          3.041µ ±  3%    2.062µ ±  4%  -32.20% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                          3.284µ ±  4%    2.295µ ±  2%  -30.12% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                          3.528µ ±  3%    2.549µ ±  6%  -27.75% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                         4.118µ ±  4%    3.113µ ±  3%  -24.41% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                         5.353µ ±  7%    4.083µ ±  1%  -23.72% (p=0.000 n=10)
WithGroupNesting/Depth1-16                           2.945µ ±  3%    1.985µ ±  5%  -32.60% (p=0.000 n=10)
WithGroupNesting/Depth3-16                           2.753µ ±  8%    1.976µ ±  6%  -28.22% (p=0.000 n=10)
WithGroupNesting/Depth5-16                           2.799µ ±  3%    2.085µ ±  3%  -25.51% (p=0.000 n=10)
WithGroupNesting/Depth10-16                          3.109µ ±  3%    2.247µ ± 25%  -27.73% (p=0.002 n=10)
MixedWithAttrsAndGroups-16                           3.946µ ±  3%    5.335µ ±  1%  +35.20% (p=0.000 n=10)
AttributeTypes/Strings-16                            2.978µ ±  3%    4.077µ ±  2%  +36.91% (p=0.000 n=10)
AttributeTypes/Ints-16                               3.342µ ±  2%    4.446µ ±  1%  +33.02% (p=0.000 n=10)
AttributeTypes/Mixed-16                              3.564µ ±  4%    5.136µ ±  2%  +44.11% (p=0.000 n=10)
AttributeTypes/LargeStrings-16                       5.480µ ±  4%    8.711µ ±  1%  +58.97% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                          3.527µ ±  3%    4.913µ ±  1%  +39.28% (p=0.000 n=10)
AttributeTypes/NestedGroups-16                       4.037µ ±  3%    6.033µ ±  2%  +49.42% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16                         867.1n ±  3%   1338.5n ±  5%  +54.36% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                         883.8n ±  2%   1160.5n ±  4%  +31.32% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                         869.5n ±  2%    737.9n ± 54%        ~ (p=0.143 n=10)
ConcurrentLogging/Scale8x-16                         857.0n ±  1%    731.4n ±  7%  -14.65% (p=0.001 n=10)
ConcurrentLogging/Scale16x-16                       1130.0n ± 27%    723.3n ± 16%  -35.99% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16                       1465.5n ±  6%    992.2n ±  2%  -32.30% (p=0.000 n=10)
HandleOnly/Preformatted0-16                          4.602µ ±  1%    1.923µ ±  6%  -58.21% (p=0.000 n=10)
HandleOnly/Preformatted5-16                          5.668µ ±  1%    2.560µ ±  4%  -54.84% (p=0.000 n=10)
HandleOnly/Preformatted20-16                         8.286µ ±  3%    4.247µ ±  2%  -48.74% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16                 6.023µ ±  7%    2.228µ ±  3%  -63.02% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16                   6.026µ ±  8%    2.160µ ±  4%  -64.14% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16                 59.14n ± 28%    39.17n ±  1%  -33.78% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtError-16                42.49n ±  2%    39.02n ±  2%   -8.17% (p=0.000 n=10)
EnabledCheck/Disabled_InfoAtWarn-16                  42.05n ±  4%    53.00n ± 27%  +26.03% (p=0.023 n=10)
EnabledCheck/Disabled_WarnAtError-16                 42.15n ±  3%    51.16n ± 10%  +21.39% (p=0.000 n=10)
LevelSelection/Debug-16                              2.611µ ±  4%    1.823µ ±  6%  -30.17% (p=0.000 n=10)
LevelSelection/Info-16                               2.573µ ±  2%    1.826µ ±  8%  -29.02% (p=0.000 n=10)
LevelSelection/Warn-16                               2.550µ ±  1%    1.887µ ±  6%  -26.01% (p=0.000 n=10)
LevelSelection/Error-16                              2.563µ ±  3%    1.858µ ±  5%  -27.51% (p=0.000 n=10)
geomean                                              1.841µ          1.478µ        -19.75%

                                      │ ../../../before.benchmark │            after.benchmark            │
                                      │           B/op            │     B/op      vs base                 │
BasicLog/NoAttrs-16                                  568.0 ± 0%       600.0 ± 0%  +5.63% (p=0.000 n=10)
BasicLog/2Attrs-16                                   809.0 ± 0%       841.0 ± 0%  +3.96% (p=0.000 n=10)
BasicLog/5Attrs-16                                 1.157Ki ± 0%     1.188Ki ± 0%  +2.70% (p=0.000 n=10)
BasicLog/10Attrs-16                                1.964Ki ± 0%     2.026Ki ± 0%  +3.18% (p=0.000 n=10)
BasicLog/20Attrs-16                                3.779Ki ± 0%     3.779Ki ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Debug-16                                   873.0 ± 0%       905.0 ± 0%  +3.67% (p=0.000 n=10)
LogLevels/Info-16                                    873.0 ± 0%       905.0 ± 0%  +3.67% (p=0.000 n=10)
LogLevels/Warn-16                                    873.0 ± 0%       905.0 ± 0%  +3.67% (p=0.000 n=10)
LogLevels/Error-16                                   873.0 ± 0%       905.0 ± 0%  +3.67% (p=0.000 n=10)
DisabledLogs-16                                      0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                          769.0 ± 0%       801.0 ± 0%  +4.16% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                          897.0 ± 0%       929.0 ± 0%  +3.57% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                        1.017Ki ± 0%     1.048Ki ± 0%  +3.07% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                       1.330Ki ± 0%     1.361Ki ± 0%  +2.35% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                       2.050Ki ± 0%     2.175Ki ± 0%  +6.10% (p=0.000 n=10)
WithGroupNesting/Depth1-16                           721.0 ± 0%       753.0 ± 0%  +4.44% (p=0.000 n=10)
WithGroupNesting/Depth3-16                           729.0 ± 0%       761.0 ± 0%  +4.39% (p=0.000 n=10)
WithGroupNesting/Depth5-16                           753.0 ± 0%       785.0 ± 0%  +4.25% (p=0.000 n=10)
WithGroupNesting/Depth10-16                          785.0 ± 0%       817.0 ± 0%  +4.08% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                         1.103Ki ± 0%     1.134Ki ± 0%  +2.83% (p=0.000 n=10)
AttributeTypes/Strings-16                            944.0 ± 0%       976.0 ± 0%  +3.39% (p=0.000 n=10)
AttributeTypes/Ints-16                               968.0 ± 0%      1000.0 ± 0%  +3.31% (p=0.000 n=10)
AttributeTypes/Mixed-16                            1.086Ki ± 0%     1.118Ki ± 0%  +2.97% (p=0.000 n=10)
AttributeTypes/LargeStrings-16                       857.0 ± 0%       889.0 ± 0%  +3.73% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                        1.259Ki ± 0%     1.353Ki ± 0%  +7.45% (p=0.000 n=10)
AttributeTypes/NestedGroups-16                     1.579Ki ± 0%     1.673Ki ± 0%  +5.94% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16                         915.0 ± 0%       947.0 ± 0%  +3.50% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                         915.0 ± 0%       947.0 ± 0%  +3.50% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                         915.0 ± 0%       947.0 ± 0%  +3.50% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                         915.0 ± 0%       947.0 ± 0%  +3.50% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16                        914.0 ± 0%       946.0 ± 0%  +3.50% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16                      1.166Ki ± 0%     1.197Ki ± 0%  +2.68% (p=0.000 n=10)
HandleOnly/Preformatted0-16                          585.0 ± 0%       617.0 ± 0%  +5.47% (p=0.000 n=10)
HandleOnly/Preformatted5-16                          905.0 ± 0%       937.0 ± 0%  +3.54% (p=0.000 n=10)
HandleOnly/Preformatted20-16                       2.012Ki ± 0%     2.012Ki ± 0%       ~ (p=1.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16                 737.0 ± 0%       769.0 ± 0%  +4.34% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16                   737.0 ± 0%       769.0 ± 0%  +4.34% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16                 32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16                32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16                  32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16                 32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                              584.0 ± 0%       616.0 ± 0%  +5.48% (p=0.000 n=10)
LevelSelection/Info-16                               584.0 ± 0%       616.0 ± 0%  +5.48% (p=0.000 n=10)
LevelSelection/Warn-16                               584.0 ± 0%       616.0 ± 0%  +5.48% (p=0.000 n=10)
LevelSelection/Error-16                              584.0 ± 0%       616.0 ± 0%  +5.48% (p=0.000 n=10)
geomean                                                         ²                 +3.45%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │ ../../../before.benchmark │           after.benchmark           │
                                      │         allocs/op         │ allocs/op   vs base                 │
BasicLog/NoAttrs-16                                  9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/2Attrs-16                                   13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/5Attrs-16                                   19.00 ± 0%     19.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/10Attrs-16                                  30.00 ± 0%     30.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/20Attrs-16                                  50.00 ± 0%     50.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Debug-16                                   14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Info-16                                    14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Warn-16                                    14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Error-16                                   14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
DisabledLogs-16                                      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                          12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth3-16                          12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth5-16                          12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth10-16                         12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth20-16                         12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth1-16                           13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth3-16                           13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth5-16                           13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth10-16                          13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
MixedWithAttrsAndGroups-16                           18.00 ± 0%     18.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Strings-16                            16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Ints-16                               19.00 ± 0%     19.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Mixed-16                              24.00 ± 0%     24.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/LargeStrings-16                       16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/GroupAttr-16                          23.00 ± 0%     23.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/NestedGroups-16                       30.00 ± 0%     30.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale1x-16                         17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale2x-16                         17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale4x-16                         17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale8x-16                         16.00 ± 0%     17.00 ± 6%  +6.25% (p=0.003 n=10)
ConcurrentLogging/Scale16x-16                        16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentWithAttrsThenLog-16                        23.00 ± 0%     23.00 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted0-16                          10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted5-16                          10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted20-16                         10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_DebugAtDebug-16                 13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_InfoAtInfo-16                   13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtInfo-16                 1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16                1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16                  1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16                 1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                              10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Info-16                               10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Warn-16                               10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Error-16                              10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                                         ²               +0.13%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
