### PR TITLE
perf: have handler write level kv directly, drop leveled loggers

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -27,8 +27,7 @@ var (
 type GoKitHandler struct {
 	level        slog.Leveler
 	logger       log.Logger
-	levelLoggers *levelLoggerCache // pre-built leveled loggers
-	preformatted []any             // pre-flattened key-value pairs, ready to pass directly to logger.Log()
+	preformatted []any // pre-flattened key-value pairs, ready to pass directly to logger.Log()
 	group        string
 }
 
@@ -51,9 +50,8 @@ func NewGoKitHandler(logger log.Logger, level slog.Leveler) slog.Handler {
 	}
 
 	return &GoKitHandler{
-		logger:       logger,
-		level:        level,
-		levelLoggers: newLevelCache(logger),
+		logger: logger,
+		level:  level,
 	}
 }
 
@@ -68,8 +66,6 @@ func (h *GoKitHandler) Enabled(_ context.Context, level slog.Level) bool {
 // are formatted and added to the log call as individual key/value pairs. It
 // implements slog.Handler.
 func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
-	logger := h.levelLoggers.get(record.Level)
-
 	// Pre-compute slice capacity. h.preformatted is already flattened to []any
 	// key-value pairs at WithAttrs time, so len(h.preformatted) is the exact
 	// item count -- no expansion buffer needed for that portion. Record attrs
@@ -77,13 +73,19 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// buffer for that portion's estimated capacity only.
 	//
 	// We know we need:
+	// - 2 for level (key + value)
 	// - 2 for caller (key + value)
 	// - 2 for timestamp (key + value)
 	// - 2 for message (key + value)
 	// - len(h.preformatted) exact items (pre-flattened, no expansion)
 	// - 2 * record.NumAttrs() for record attrs, +50% buffer for group expansion
-	capacity := 6 + len(h.preformatted) + (3 * record.NumAttrs())
+	capacity := 8 + len(h.preformatted) + (3 * record.NumAttrs())
 	pairs := make([]any, 0, capacity)
+
+	// Append the level directly as the first pair. Matches how the log
+	// message is constructed through level.Info()/level.Debug()/etc
+	// wrappers, but without the extra allocation/copy per call.
+	pairs = append(pairs, levelKey, gokitLevelValue(record.Level))
 
 	// Resolve the log call site from the PC that slog captured when the
 	// record was created. Cheaper and more accurate to do it here since
@@ -117,7 +119,7 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 		return true
 	})
 
-	return logger.Log(pairs...)
+	return h.logger.Log(pairs...)
 }
 
 // WithAttrs formats the provided attributes and caches them in the handler to
@@ -140,7 +142,6 @@ func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
-		levelLoggers: h.levelLoggers,
 		preformatted: pairs,
 		group:        h.group,
 	}
@@ -161,7 +162,6 @@ func (h *GoKitHandler) WithGroup(name string) slog.Handler {
 	return &GoKitHandler{
 		logger:       h.logger,
 		level:        h.level,
-		levelLoggers: h.levelLoggers,
 		preformatted: h.preformatted,
 		group:        g,
 	}

--- a/level.go
+++ b/level.go
@@ -3,38 +3,34 @@ package sloggokit
 import (
 	"log/slog"
 
-	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 )
 
-// levelLoggerCache holds pre-built leveled loggers so that Handle() can
-// retrieve an existing leveled logger rather than creating a new one each
-// time.
-type levelLoggerCache struct {
-	debugLogger log.Logger
-	infoLogger  log.Logger
-	warnLogger  log.Logger
-	errorLogger log.Logger
-}
+// go-kit/log hoists these into package level variables to pre-pay boxing cost
+// once, same that we do for slog keys in the handler:
+// https://github.com/go-kit/log/blob/v0.2.1/level/level.go#L229-L239
+//
+// Re-hoist them here for the same reasons so they can be appended right into
+// the log's kv pairs.
+var (
+	levelKey        any = level.Key()
+	debugLevelValue any = level.DebugValue()
+	infoLevelValue  any = level.InfoValue()
+	warnLevelValue  any = level.WarnValue()
+	errorLevelValue any = level.ErrorValue()
+)
 
-func newLevelCache(logger log.Logger) *levelLoggerCache {
-	return &levelLoggerCache{
-		debugLogger: level.Debug(logger),
-		infoLogger:  level.Info(logger),
-		warnLogger:  level.Warn(logger),
-		errorLogger: level.Error(logger),
-	}
-}
-
-func (c *levelLoggerCache) get(lvl slog.Level) log.Logger {
+// gokitLevelValue maps an slog.Level to the boxed go-kit level value.
+// Unnamed levels bucket to the highest named level at or below them.
+func gokitLevelValue(lvl slog.Level) any {
 	switch {
 	case lvl >= slog.LevelError:
-		return c.errorLogger
+		return errorLevelValue
 	case lvl >= slog.LevelWarn:
-		return c.warnLogger
+		return warnLevelValue
 	case lvl >= slog.LevelInfo:
-		return c.infoLogger
+		return infoLevelValue
 	default:
-		return c.debugLogger
+		return debugLevelValue
 	}
 }


### PR DESCRIPTION
go-kit's level.Debug/Info/Warn/Error helpers return a log context, and
context.Log() merges the stored kv pairs with the per-call pairs into a
freshly allocated slice on every log call:
https://github.com/go-kit/log/blob/v0.2.1/log.go#L151-L155

Handle() is already building the complete kv pair slice for the logger
to dispatch, so rather than relying on the wrappers, we now just write
the level directly in the first kv slot, same as how the wrappers work,
just without the extra alloc/copy.

Benchmarks:
```
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │ ../../../before.benchmark │           after.benchmark            │
                                      │          sec/op           │    sec/op     vs base                │
BasicLog/NoAttrs-16                                  3.325µ ±  3%   3.116µ ±  5%   -6.30% (p=0.000 n=10)
BasicLog/2Attrs-16                                   4.308µ ±  4%   4.012µ ±  5%   -6.86% (p=0.000 n=10)
BasicLog/5Attrs-16                                   5.650µ ±  7%   5.378µ ±  5%        ~ (p=0.075 n=10)
BasicLog/10Attrs-16                                  7.999µ ±  5%   7.568µ ±  7%   -5.38% (p=0.005 n=10)
BasicLog/20Attrs-16                                  12.19µ ±  3%   11.70µ ±  3%   -4.04% (p=0.001 n=10)
LogLevels/Debug-16                                   4.555µ ±  3%   4.341µ ±  3%   -4.71% (p=0.002 n=10)
LogLevels/Info-16                                    4.429µ ±  4%   4.287µ ±  8%        ~ (p=0.063 n=10)
LogLevels/Warn-16                                    4.406µ ±  7%   4.276µ ±  5%   -2.96% (p=0.015 n=10)
LogLevels/Error-16                                   4.472µ ± 45%   4.231µ ±  5%        ~ (p=0.631 n=10)
DisabledLogs-16                                      9.256n ± 16%   8.105n ± 16%        ~ (p=0.143 n=10)
WithAttrsChaining/Depth1-16                          4.314µ ±  5%   3.535µ ± 23%  -18.06% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                          4.946µ ±  5%   4.666µ ± 10%   -5.66% (p=0.043 n=10)
WithAttrsChaining/Depth5-16                          5.546µ ±  4%   5.130µ ±  4%   -7.51% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                         6.601µ ±  3%   6.082µ ±  5%   -7.86% (p=0.001 n=10)
WithAttrsChaining/Depth20-16                         8.388µ ± 10%   8.007µ ±  3%        ~ (p=0.052 n=10)
WithGroupNesting/Depth1-16                           4.176µ ± 16%   3.940µ ±  4%   -5.64% (p=0.043 n=10)
WithGroupNesting/Depth3-16                           4.378µ ±  6%   4.148µ ± 11%   -5.26% (p=0.009 n=10)
WithGroupNesting/Depth5-16                           4.737µ ±  5%   4.246µ ± 14%  -10.36% (p=0.000 n=10)
WithGroupNesting/Depth10-16                          4.930µ ±  7%   4.860µ ±  5%        ~ (p=0.739 n=10)
MixedWithAttrsAndGroups-16                           6.255µ ± 13%   5.888µ ±  8%        ~ (p=0.079 n=10)
AttributeTypes/Strings-16                            4.873µ ±  7%   4.735µ ±  2%        ~ (p=0.280 n=10)
AttributeTypes/Ints-16                               5.483µ ±  5%   5.043µ ±  5%   -8.02% (p=0.000 n=10)
AttributeTypes/Mixed-16                              5.365µ ±  6%   5.931µ ±  4%  +10.55% (p=0.000 n=10)
AttributeTypes/LargeStrings-16                       9.151µ ± 13%   8.930µ ±  8%        ~ (p=0.739 n=10)
AttributeTypes/GroupAttr-16                          5.967µ ±  8%   4.864µ ±  8%  -18.49% (p=0.000 n=10)
AttributeTypes/NestedGroups-16                       7.827µ ±  5%   7.305µ ±  6%   -6.67% (p=0.004 n=10)
ConcurrentLogging/Scale1x-16                        1488.0n ± 16%   977.4n ± 24%  -34.31% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                         1.743µ ±  6%   1.386µ ±  7%  -20.51% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                         1.712µ ± 10%   1.373µ ±  8%  -19.81% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                         1.654µ ± 14%   1.390µ ± 14%  -15.96% (p=0.001 n=10)
ConcurrentLogging/Scale16x-16                        1.488µ ± 12%   1.298µ ±  6%  -12.80% (p=0.001 n=10)
ConcurrentWithAttrsThenLog-16                        1.273µ ±  3%   1.914µ ± 10%  +50.35% (p=0.000 n=10)
HandleOnly/Preformatted0-16                          3.724µ ±  2%   3.769µ ±  2%   +1.19% (p=0.035 n=10)
HandleOnly/Preformatted5-16                          4.957µ ±  5%   4.492µ ±  3%   -9.39% (p=0.000 n=10)
HandleOnly/Preformatted20-16                         7.805µ ±  4%   7.344µ ±  3%   -5.91% (p=0.002 n=10)
EnabledCheck/Enabled_DebugAtDebug-16                 4.281µ ± 10%   4.200µ ±  6%        ~ (p=0.529 n=10)
EnabledCheck/Enabled_InfoAtInfo-16                   4.409µ ±  3%   4.080µ ± 10%   -7.45% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16                 76.23n ±  4%   75.44n ±  4%        ~ (p=0.218 n=10)
EnabledCheck/Disabled_DebugAtError-16                75.85n ±  4%   75.87n ±  4%        ~ (p=1.000 n=10)
EnabledCheck/Disabled_InfoAtWarn-16                  76.46n ± 10%   76.16n ±  3%        ~ (p=0.631 n=10)
EnabledCheck/Disabled_WarnAtError-16                 73.83n ±  4%   76.24n ±  4%        ~ (p=0.105 n=10)
LevelSelection/Debug-16                              3.477µ ±  7%   3.118µ ±  6%  -10.33% (p=0.003 n=10)
LevelSelection/Info-16                               3.241µ ±  6%   3.305µ ±  8%        ~ (p=0.853 n=10)
LevelSelection/Warn-16                               3.391µ ± 16%   3.229µ ±  9%        ~ (p=0.218 n=10)
LevelSelection/Error-16                              3.335µ ±  4%   3.188µ ± 16%        ~ (p=0.165 n=10)
geomean                                              2.602µ         2.443µ         -6.10%

                                      │ ../../../before.benchmark │            after.benchmark             │
                                      │           B/op            │     B/op      vs base                  │
BasicLog/NoAttrs-16                                  600.0 ± 0%       504.0 ± 0%  -16.00% (p=0.000 n=10)
BasicLog/2Attrs-16                                   841.0 ± 0%       681.0 ± 0%  -19.02% (p=0.000 n=10)
BasicLog/5Attrs-16                                  1217.0 ± 0%       961.0 ± 0%  -21.04% (p=0.000 n=10)
BasicLog/10Attrs-16                                2.026Ki ± 0%     1.588Ki ± 0%  -21.64% (p=0.000 n=10)
BasicLog/20Attrs-16                                3.779Ki ± 0%     2.903Ki ± 0%  -23.18% (p=0.000 n=10)
LogLevels/Debug-16                                   905.0 ± 0%       745.0 ± 0%  -17.68% (p=0.000 n=10)
LogLevels/Info-16                                    905.0 ± 0%       745.0 ± 0%  -17.68% (p=0.000 n=10)
LogLevels/Warn-16                                    905.0 ± 0%       745.0 ± 0%  -17.68% (p=0.000 n=10)
LogLevels/Error-16                                   905.0 ± 0%       745.0 ± 0%  -17.68% (p=0.000 n=10)
DisabledLogs-16                                      0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                          801.0 ± 0%       641.0 ± 0%  -19.98% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                          929.0 ± 0%       721.0 ± 0%  -22.39% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                         1073.0 ± 0%       785.0 ± 0%  -26.84% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                        1394.0 ± 0%       945.0 ± 0%  -32.21% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                       2.175Ki ± 0%     1.299Ki ± 0%  -40.28% (p=0.000 n=10)
WithGroupNesting/Depth1-16                           753.0 ± 0%       624.0 ± 0%  -17.13% (p=0.000 n=10)
WithGroupNesting/Depth3-16                           761.0 ± 0%       633.0 ± 0%  -16.82% (p=0.000 n=10)
WithGroupNesting/Depth5-16                           785.0 ± 0%       657.0 ± 0%  -16.31% (p=0.000 n=10)
WithGroupNesting/Depth10-16                          817.0 ± 0%       689.0 ± 0%  -15.67% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                          1161.0 ± 0%       873.0 ± 0%  -24.81% (p=0.000 n=10)
AttributeTypes/Strings-16                            976.0 ± 0%       800.0 ± 0%  -18.03% (p=0.000 n=10)
AttributeTypes/Ints-16                              1000.0 ± 0%       824.0 ± 0%  -17.60% (p=0.000 n=10)
AttributeTypes/Mixed-16                             1145.0 ± 0%       920.0 ± 0%  -19.65% (p=0.000 n=10)
AttributeTypes/LargeStrings-16                       889.0 ± 0%       729.0 ± 0%  -18.00% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                        1.353Ki ± 0%     1.259Ki ± 0%   -6.93% (p=0.000 n=10)
AttributeTypes/NestedGroups-16                     1.673Ki ± 0%     1.548Ki ± 0%   -7.47% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16                         947.0 ± 0%       754.0 ± 0%  -20.38% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                         947.0 ± 0%       754.5 ± 0%  -20.33% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                         947.0 ± 0%       754.0 ± 0%  -20.38% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                         946.0 ± 0%       754.0 ± 0%  -20.30% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16                        946.0 ± 0%       753.0 ± 0%  -20.40% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16                      1.197Ki ± 0%     1.040Ki ± 0%  -13.13% (p=0.000 n=10)
HandleOnly/Preformatted0-16                          617.0 ± 0%       521.0 ± 0%  -15.56% (p=0.000 n=10)
HandleOnly/Preformatted5-16                          937.0 ± 0%       681.0 ± 0%  -27.32% (p=0.000 n=10)
HandleOnly/Preformatted20-16                       2.012Ki ± 0%     1.260Ki ± 0%  -37.38% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16                 769.0 ± 0%       641.0 ± 0%  -16.64% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16                   769.0 ± 0%       641.0 ± 0%  -16.64% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16                 32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16                32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16                  32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16                 32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                              616.0 ± 0%       520.0 ± 0%  -15.58% (p=0.000 n=10)
LevelSelection/Info-16                               616.0 ± 0%       520.0 ± 0%  -15.58% (p=0.000 n=10)
LevelSelection/Warn-16                               616.0 ± 0%       520.0 ± 0%  -15.58% (p=0.000 n=10)
LevelSelection/Error-16                              616.0 ± 0%       520.0 ± 0%  -15.58% (p=0.000 n=10)
geomean                                                         ²                 -17.84%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │ ../../../before.benchmark │           after.benchmark            │
                                      │         allocs/op         │ allocs/op   vs base                  │
BasicLog/NoAttrs-16                                  9.000 ± 0%     8.000 ± 0%  -11.11% (p=0.000 n=10)
BasicLog/2Attrs-16                                   13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
BasicLog/5Attrs-16                                   19.00 ± 0%     18.00 ± 0%   -5.26% (p=0.000 n=10)
BasicLog/10Attrs-16                                  30.00 ± 0%     29.00 ± 0%   -3.33% (p=0.000 n=10)
BasicLog/20Attrs-16                                  50.00 ± 0%     49.00 ± 0%   -2.00% (p=0.000 n=10)
LogLevels/Debug-16                                   14.00 ± 0%     13.00 ± 0%   -7.14% (p=0.000 n=10)
LogLevels/Info-16                                    14.00 ± 0%     13.00 ± 0%   -7.14% (p=0.000 n=10)
LogLevels/Warn-16                                    14.00 ± 0%     13.00 ± 0%   -7.14% (p=0.000 n=10)
LogLevels/Error-16                                   14.00 ± 0%     13.00 ± 0%   -7.14% (p=0.000 n=10)
DisabledLogs-16                                      0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16                          12.00 ± 0%     11.00 ± 0%   -8.33% (p=0.000 n=10)
WithAttrsChaining/Depth3-16                          12.00 ± 0%     11.00 ± 0%   -8.33% (p=0.000 n=10)
WithAttrsChaining/Depth5-16                          12.00 ± 0%     11.00 ± 0%   -8.33% (p=0.000 n=10)
WithAttrsChaining/Depth10-16                         12.00 ± 0%     11.00 ± 0%   -8.33% (p=0.000 n=10)
WithAttrsChaining/Depth20-16                         12.00 ± 0%     11.00 ± 0%   -8.33% (p=0.000 n=10)
WithGroupNesting/Depth1-16                           13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
WithGroupNesting/Depth3-16                           13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
WithGroupNesting/Depth5-16                           13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
WithGroupNesting/Depth10-16                          13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                           18.00 ± 0%     17.00 ± 0%   -5.56% (p=0.000 n=10)
AttributeTypes/Strings-16                            16.00 ± 0%     15.00 ± 0%   -6.25% (p=0.000 n=10)
AttributeTypes/Ints-16                               19.00 ± 0%     18.00 ± 0%   -5.26% (p=0.000 n=10)
AttributeTypes/Mixed-16                              24.00 ± 0%     23.00 ± 0%   -4.17% (p=0.000 n=10)
AttributeTypes/LargeStrings-16                       16.00 ± 0%     15.00 ± 0%   -6.25% (p=0.000 n=10)
AttributeTypes/GroupAttr-16                          23.00 ± 0%     22.00 ± 0%   -4.35% (p=0.000 n=10)
AttributeTypes/NestedGroups-16                       30.00 ± 0%     29.00 ± 0%   -3.33% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16                         17.00 ± 0%     16.00 ± 0%   -5.88% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16                         17.00 ± 0%     16.00 ± 0%   -5.88% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16                         16.50 ± 3%     15.00 ± 7%   -9.09% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16                         16.00 ± 0%     15.00 ± 0%   -6.25% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16                        16.00 ± 0%     15.00 ± 0%   -6.25% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16                        23.00 ± 0%     22.00 ± 0%   -4.35% (p=0.000 n=10)
HandleOnly/Preformatted0-16                         10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
HandleOnly/Preformatted5-16                         10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
HandleOnly/Preformatted20-16                        10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16                 13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16                   13.00 ± 0%     12.00 ± 0%   -7.69% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16                 1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16                1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16                  1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16                 1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                             10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
LevelSelection/Info-16                              10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
LevelSelection/Warn-16                              10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
LevelSelection/Error-16                             10.000 ± 0%     9.000 ± 0%  -10.00% (p=0.000 n=10)
geomean                                                         ²                -6.46%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
