### PR TITLE
perf(handler): cache resolved caller strings by record PC

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 
 	"github.com/go-kit/log"
 )
@@ -21,6 +22,19 @@ var (
 	msgKey    any = slog.MessageKey
 	callerKey any = "caller"
 )
+
+// callerCache memoizes resolved caller strings keyed by record PC. A PC's
+// file:line mapping is fixed for the process lifetime and log call sites are
+// static, so the cache is write-once, read-many and bounded by the number of
+// distinct call sites. 
+//
+// Kubernetes's klog does something similar to cache per-call-site verbosity
+// levels by PC (`vmap` in
+// https://github.com/kubernetes/klog/blob/main/klog.go).
+//
+// Values are stored pre-boxed as `any` so cache hits append into the pairs
+// slice with zero allocations, and no need to walk the call stack.
+var callerCache sync.Map // map[uintptr]any, values are `file:line` strings.
 
 // GoKitHandler implements the slog.Handler interface. It holds an internal
 // go-kit logger that is used to perform the true logging.
@@ -92,16 +106,22 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// it's already captured, vs relying on setting `log.Caller()` depth
 	// and hoping it unwinds correctly.
 	if record.PC != 0 {
-		fs := runtime.CallersFrames([]uintptr{record.PC})
-		f, _ := fs.Next()
-		if f.File != "" {
-			// Trim to basename:line with the same logic as
-			// go-kit's log.Caller:
-			// https://github.com/go-kit/log/blob/v0.2.1/value.go#L84-L93
-			// 
-			// path.Base() would work, opting for direct compatibility.
-			idx := strings.LastIndexByte(f.File, '/')
-			pairs = append(pairs, callerKey, f.File[idx+1:]+":"+strconv.Itoa(f.Line))
+		if caller, ok := callerCache.Load(record.PC); ok {
+			pairs = append(pairs, callerKey, caller)
+		} else {
+			fs := runtime.CallersFrames([]uintptr{record.PC})
+			f, _ := fs.Next()
+			if f.File != "" {
+				// Trim to basename:line with the same logic as
+				// go-kit's log.Caller:
+				// https://github.com/go-kit/log/blob/v0.2.1/value.go#L84-L93
+				//
+				// path.Base() would work, opting for direct compatibility.
+				idx := strings.LastIndexByte(f.File, '/')
+				caller := any(f.File[idx+1:] + ":" + strconv.Itoa(f.Line))
+				callerCache.Store(record.PC, caller)
+				pairs = append(pairs, callerKey, caller)
+			}
 		}
 	}
 

--- a/handler_bench_test.go
+++ b/handler_bench_test.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-kit/log"
 	slgk "github.com/tjhop/slog-gokit"
@@ -341,6 +343,88 @@ func BenchmarkEnabledCheck(b *testing.B) {
 				logFn("benchmark message", "key", "value")
 			}
 		})
+	}
+}
+
+// BenchmarkCallerCache measures the caller-resolution path in Handle() by
+// dispatching records directly to the handler:
+//
+//   - Hit: the record PC is already cached, the steady state every log call
+//     after the first from a given site takes. The caller portion must stay
+//     zero-allocation (the cached value is pre-boxed).
+//   - NoPC: records without a PC skip caller handling entirely, the floor.
+//
+// Both cases go through the public API only, so they stay comparable across
+// versions: on refs without the PC cache, Hit simply measures whatever
+// per-call caller resolution that version performs from the same warmed,
+// repeated call site. The miss path is deliberately not benchmarked:
+// forcing a miss would require evicting the unexported cache entry, which
+// the public API cannot do, and cross-version it needs no dedicated
+// benchmark anyway -- on refs without the cache, Hit measures the
+// always-resolve cost that a miss approximates.
+func BenchmarkCallerCache(b *testing.B) {
+	h := slgk.NewGoKitHandler(log.NewLogfmtLogger(io.Discard), nil)
+	ctx := context.Background()
+
+	pcs := make([]uintptr, 1)
+	runtime.Callers(1, pcs)
+	pc := pcs[0]
+
+	record := slog.NewRecord(time.Now(), slog.LevelInfo, "benchmark message", pc)
+	noPCRecord := slog.NewRecord(time.Now(), slog.LevelInfo, "benchmark message", 0)
+
+	b.Run("Hit", func(b *testing.B) {
+		// Warm the cache so the first iteration is not a miss.
+		_ = h.Handle(ctx, record)
+
+		b.ResetTimer()
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = h.Handle(ctx, record)
+		}
+	})
+
+	b.Run("NoPC", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			_ = h.Handle(ctx, noPCRecord)
+		}
+	})
+}
+
+// BenchmarkCallerCacheSites rotates logging across several distinct call
+// sites. The rest of the suite loops on a single call site, which measures
+// caller-cache hits against one hot map entry; this measures the same hit
+// path with a populated cache and a different key every iteration. Results
+// should stay in line with the single-site benchmarks -- a divergence means
+// hit cost degrades as the cache grows, which would matter for real programs
+// logging from many sites.
+func BenchmarkCallerCacheSites(b *testing.B) {
+	h := slgk.NewGoKitHandler(log.NewLogfmtLogger(io.Discard), nil)
+	logger := slog.New(h)
+
+	// One closure per line: each body is a distinct call site with its own
+	// PC and cache entry.
+	sites := []func(){
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+		func() { logger.Info("benchmark message") },
+	}
+
+	// Warm every site so the measured loop is all cache hits.
+	for _, site := range sites {
+		site()
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		sites[i%len(sites)]()
 	}
 }
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -418,3 +418,84 @@ func TestCaller(t *testing.T) {
 		require.NotContains(t, buf.String(), "caller=")
 	})
 }
+
+// TestCallerCache verifies that cached caller resolution stays keyed to the
+// right call site: repeated logs from one site (cache hits after the first
+// resolution) and logs from distinct sites must each report their own
+// file:line.
+func TestCallerCache(t *testing.T) {
+	var buf bytes.Buffer
+	slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil))
+
+	_, file, line, _ := runtime.Caller(0)
+	slogger.Info("first")  // cache miss, resolves and stores this PC
+	slogger.Info("second") // distinct call site, its own PC and line
+	for i := 0; i < 3; i++ {
+		slogger.Info("loop") // misses once, then hits the cached PC
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 5)
+
+	base := filepath.Base(file)
+	require.Contains(t, lines[0], fmt.Sprintf("caller=%s:%d", base, line+1))
+	require.Contains(t, lines[1], fmt.Sprintf("caller=%s:%d", base, line+2))
+	for _, logLine := range lines[2:] {
+		require.Contains(t, logLine, fmt.Sprintf("caller=%s:%d", base, line+4))
+	}
+}
+
+// TestConcurrentHandle drives Handle() concurrently through a single handler
+// from multiple call sites. Under -race this covers the caller cache's
+// concurrent paths: goroutines racing to first-resolve the same PC and
+// lock-free reads on cache hits. TestWithAttrsConcurrency only exercises
+// WithAttrs, so without this test the Handle path has no race coverage at
+// all. Every emitted line is checked against the set of known call sites.
+func TestConcurrentHandle(t *testing.T) {
+	var buf bytes.Buffer
+	// SyncWriter serializes the underlying writes so concurrently logged
+	// lines cannot interleave mid-line.
+	slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(log.NewSyncWriter(&buf)), nil))
+
+	_, file, line, _ := runtime.Caller(0)
+	sites := []func(){
+		func() { slogger.Info("concurrent site a") },
+		func() { slogger.Info("concurrent site b") },
+		func() { slogger.Info("concurrent site c") },
+	}
+
+	const numGoroutines = 8
+	const iterations = 200
+
+	var wg sync.WaitGroup
+	wg.Add(numGoroutines)
+	for g := 0; g < numGoroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				sites[(id+i)%len(sites)]()
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	base := filepath.Base(file)
+	want := []string{
+		fmt.Sprintf("caller=%s:%d", base, line+2),
+		fmt.Sprintf("caller=%s:%d", base, line+3),
+		fmt.Sprintf("caller=%s:%d", base, line+4),
+	}
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, numGoroutines*iterations)
+	for _, logLine := range lines {
+		matched := false
+		for _, w := range want {
+			if strings.Contains(logLine, w) {
+				matched = true
+				break
+			}
+		}
+		require.True(t, matched, "log line has unexpected caller: %s", logLine)
+	}
+}


### PR DESCRIPTION
Resolving the caller on every Handle() call re-walks the call stack, but
log call sties are static and a PC's `file:line` mapping isn't going to
change for the process lifetime. This memoizes the caller string into a
sync.Map, pre-boxed as an `any` so it can appended into the pairs inline
with no allocations. Cache here is write-once, read-many. Since the map
is keyed on PC, it's bounded by the number of unique call sites. Even
with hundreds of thousands of call sites, the memory usage of the map
would be in the low MB, likely a rounding error in the greater context
of the program using this adapter. Kubernetes' klog package does
something similar for verbosity levels, so there is indeed precedent for
treating PCs as stable keys.

benchstat output:
```
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit/benchmarks
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │    head.txt    │             pc-cache.txt             │
                                      │     sec/op     │    sec/op     vs base                │
BasicLog/NoAttrs-16                     1083.5n ±   2%   818.4n ±  1%  -24.47% (p=0.000 n=10)
BasicLog/2Attrs-16                       1.403µ ±   4%   1.148µ ±  3%  -18.15% (p=0.000 n=10)
BasicLog/5Attrs-16                       1.852µ ±  17%   1.589µ ±  1%  -14.20% (p=0.000 n=10)
BasicLog/10Attrs-16                      2.776µ ±   4%   2.312µ ±  3%  -16.73% (p=0.000 n=10)
BasicLog/20Attrs-16                      4.311µ ±   8%   3.755µ ±  2%  -12.91% (p=0.000 n=10)
LogLevels/Debug-16                       1.461µ ±   8%   1.196µ ±  1%  -18.17% (p=0.000 n=10)
LogLevels/Info-16                        1.462µ ±   1%   1.205µ ±  2%  -17.58% (p=0.000 n=10)
LogLevels/Warn-16                        1.450µ ±   2%   1.204µ ±  2%  -17.00% (p=0.000 n=10)
LogLevels/Error-16                       1.450µ ±   1%   1.208µ ±  2%  -16.69% (p=0.000 n=10)
DisabledLogs-16                          5.892n ±   5%   5.765n ±  5%        ~ (p=0.481 n=10)
WithAttrsChaining/Depth1-16              1.335µ ±   1%   1.068µ ±  1%  -20.00% (p=0.000 n=10)
WithAttrsChaining/Depth3-16              1.488µ ±   1%   1.224µ ±  1%  -17.78% (p=0.000 n=10)
WithAttrsChaining/Depth5-16              1.625µ ±   2%   1.356µ ±  5%  -16.53% (p=0.000 n=10)
WithAttrsChaining/Depth10-16             1.946µ ±   1%   1.700µ ±  2%  -12.64% (p=0.000 n=10)
WithAttrsChaining/Depth20-16             2.605µ ±   2%   2.311µ ±  1%  -11.27% (p=0.000 n=10)
WithGroupNesting/Depth1-16               1.327µ ±   1%   1.056µ ±  1%  -20.42% (p=0.000 n=10)
WithGroupNesting/Depth3-16               1.372µ ±   2%   1.097µ ±  1%  -20.05% (p=0.000 n=10)
WithGroupNesting/Depth5-16               1.396µ ±   2%   1.127µ ±  1%  -19.31% (p=0.000 n=10)
WithGroupNesting/Depth10-16              1.492µ ±   5%   1.223µ ±  1%  -18.00% (p=0.000 n=10)
MixedWithAttrsAndGroups-16               1.991µ ±   3%   1.663µ ±  4%  -16.45% (p=0.000 n=10)
AttributeTypes/Strings-16                1.540µ ±   5%   1.248µ ±  1%  -18.90% (p=0.000 n=10)
AttributeTypes/Ints-16                   1.668µ ±   3%   1.425µ ±  5%  -14.60% (p=0.000 n=10)
AttributeTypes/Mixed-16                  1.979µ ±   2%   1.668µ ± 13%  -15.72% (p=0.000 n=10)
AttributeTypes/LargeStrings-16           3.410µ ±   1%   3.124µ ±  3%   -8.37% (p=0.000 n=10)
AttributeTypes/GroupAttr-16              1.871µ ±   5%   1.521µ ±  1%  -18.68% (p=0.000 n=10)
AttributeTypes/NestedGroups-16           2.256µ ±   1%   1.959µ ±  7%  -13.16% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16             446.0n ±   5%   329.2n ±  3%  -26.17% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16             495.6n ±   2%   353.8n ±  2%  -28.60% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16             505.4n ±   2%   365.7n ±  1%  -27.66% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16             520.1n ±   1%   372.0n ±  1%  -28.48% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16            521.2n ±   1%   377.8n ±  1%  -27.50% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16            644.5n ±   4%   491.0n ±  1%  -23.82% (p=0.000 n=10)
HandleOnly/Preformatted0-16             1156.0n ±   2%   862.1n ±  1%  -25.43% (p=0.000 n=10)
HandleOnly/Preformatted5-16              1.692µ ±  18%   1.201µ ±  2%  -29.00% (p=0.000 n=10)
HandleOnly/Preformatted20-16             3.113µ ±  10%   2.090µ ±  1%  -32.86% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16     1.636µ ±  16%   1.074µ ±  1%  -34.38% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16       1.388µ ±   6%   1.074µ ±  1%  -22.63% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16     27.29n ±   6%   26.38n ±  2%   -3.34% (p=0.001 n=10)
EnabledCheck/Disabled_DebugAtError-16    27.04n ±  11%   26.48n ±  5%   -2.05% (p=0.045 n=10)
EnabledCheck/Disabled_InfoAtWarn-16      27.80n ±   2%   26.68n ±  2%   -4.03% (p=0.000 n=10)
EnabledCheck/Disabled_WarnAtError-16     44.01n ±  36%   26.70n ±  1%  -39.34% (p=0.000 n=10)
CallerCache/Hit-16                      1003.6n ± 102%   633.3n ±  1%  -36.90% (p=0.000 n=10)
CallerCache/NoPC-16                      559.7n ±   4%   543.0n ±  4%   -2.99% (p=0.009 n=10)
CallerCacheSites-16                      1.349µ ±   1%   1.009µ ±  0%  -25.20% (p=0.000 n=10)
LevelSelection/Debug-16                 1122.5n ±   4%   790.9n ±  1%  -29.55% (p=0.000 n=10)
LevelSelection/Info-16                  1119.0n ±   2%   790.6n ±  4%  -29.35% (p=0.000 n=10)
LevelSelection/Warn-16                  1137.5n ±   2%   787.7n ±  1%  -30.75% (p=0.000 n=10)
LevelSelection/Error-16                 1123.0n ±   3%   787.8n ±  1%  -29.85% (p=0.000 n=10)
geomean                                  881.7n          700.9n        -20.50%

                                      │    head.txt    │              pc-cache.txt              │
                                      │      B/op      │     B/op      vs base                  │
BasicLog/NoAttrs-16                       504.0 ± 0%       216.0 ± 0%  -57.14% (p=0.000 n=10)
BasicLog/2Attrs-16                        681.0 ± 0%       392.0 ± 0%  -42.44% (p=0.000 n=10)
BasicLog/5Attrs-16                        961.0 ± 0%       673.0 ± 0%  -29.97% (p=0.000 n=10)
BasicLog/10Attrs-16                     1.588Ki ± 0%     1.307Ki ± 0%  -17.71% (p=0.000 n=10)
BasicLog/20Attrs-16                     2.902Ki ± 0%     2.621Ki ± 0%   -9.69% (p=0.000 n=10)
LogLevels/Debug-16                        745.0 ± 0%       456.0 ± 0%  -38.79% (p=0.000 n=10)
LogLevels/Info-16                         745.0 ± 0%       456.0 ± 0%  -38.79% (p=0.000 n=10)
LogLevels/Warn-16                         745.0 ± 0%       456.0 ± 0%  -38.79% (p=0.000 n=10)
LogLevels/Error-16                        745.0 ± 0%       456.0 ± 0%  -38.79% (p=0.000 n=10)
DisabledLogs-16                           0.000 ± 0%       0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16               640.0 ± 0%       336.0 ± 0%  -47.50% (p=0.000 n=10)
WithAttrsChaining/Depth3-16               721.0 ± 0%       416.0 ± 0%  -42.30% (p=0.000 n=10)
WithAttrsChaining/Depth5-16               785.0 ± 0%       480.0 ± 0%  -38.85% (p=0.000 n=10)
WithAttrsChaining/Depth10-16              945.0 ± 0%       641.0 ± 0%  -32.17% (p=0.000 n=10)
WithAttrsChaining/Depth20-16            1.299Ki ± 0%     1.001Ki ± 0%  -22.93% (p=0.000 n=10)
WithGroupNesting/Depth1-16                624.0 ± 0%       320.0 ± 0%  -48.72% (p=0.000 n=10)
WithGroupNesting/Depth3-16                632.0 ± 0%       328.0 ± 0%  -48.10% (p=0.000 n=10)
WithGroupNesting/Depth5-16                657.0 ± 0%       352.0 ± 0%  -46.42% (p=0.000 n=10)
WithGroupNesting/Depth10-16               689.0 ± 0%       384.0 ± 0%  -44.27% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                873.0 ± 0%       568.0 ± 0%  -34.94% (p=0.000 n=10)
AttributeTypes/Strings-16                 800.0 ± 0%       496.0 ± 0%  -38.00% (p=0.000 n=10)
AttributeTypes/Ints-16                    824.0 ± 0%       520.0 ± 0%  -36.89% (p=0.000 n=10)
AttributeTypes/Mixed-16                   920.0 ± 0%       616.0 ± 0%  -33.04% (p=0.000 n=10)
AttributeTypes/LargeStrings-16            728.5 ± 0%       424.0 ± 0%  -41.80% (p=0.000 n=10)
AttributeTypes/GroupAttr-16              1289.0 ± 0%       984.0 ± 0%  -23.66% (p=0.000 n=10)
AttributeTypes/NestedGroups-16          1.548Ki ± 0%     1.251Ki ± 0%  -19.18% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16              754.0 ± 0%       449.0 ± 0%  -40.45% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16              755.0 ± 0%       449.0 ± 0%  -40.53% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16              755.0 ± 0%       449.0 ± 0%  -40.53% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16              755.0 ± 0%       449.0 ± 0%  -40.53% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16             754.0 ± 0%       449.0 ± 0%  -40.45% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16            1067.0 ± 0%       762.0 ± 0%  -28.58% (p=0.000 n=10)
HandleOnly/Preformatted0-16               520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
HandleOnly/Preformatted5-16               681.0 ± 0%       376.0 ± 0%  -44.79% (p=0.000 n=10)
HandleOnly/Preformatted20-16             1290.0 ± 0%       985.0 ± 0%  -23.64% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16      641.0 ± 0%       336.0 ± 0%  -47.58% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16        641.0 ± 0%       336.0 ± 0%  -47.58% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16      32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16     32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16       32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16      32.00 ± 0%       32.00 ± 0%        ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                        520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
CallerCache/NoPC-16                       216.0 ± 0%       216.0 ± 0%        ~ (p=1.000 n=10) ¹
CallerCacheSites-16                       520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
LevelSelection/Debug-16                   520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
LevelSelection/Info-16                    520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
LevelSelection/Warn-16                    520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
LevelSelection/Error-16                   520.0 ± 0%       216.0 ± 0%  -58.46% (p=0.000 n=10)
geomean                                              ²                 -37.96%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │   head.txt    │             pc-cache.txt             │
                                      │   allocs/op   │ allocs/op   vs base                  │
BasicLog/NoAttrs-16                      8.000 ± 0%     4.000 ± 0%  -50.00% (p=0.000 n=10)
BasicLog/2Attrs-16                      12.000 ± 0%     8.000 ± 0%  -33.33% (p=0.000 n=10)
BasicLog/5Attrs-16                       18.00 ± 0%     14.00 ± 0%  -22.22% (p=0.000 n=10)
BasicLog/10Attrs-16                      29.00 ± 0%     25.00 ± 0%  -13.79% (p=0.000 n=10)
BasicLog/20Attrs-16                      49.00 ± 0%     45.00 ± 0%   -8.16% (p=0.000 n=10)
LogLevels/Debug-16                      13.000 ± 0%     9.000 ± 0%  -30.77% (p=0.000 n=10)
LogLevels/Info-16                       13.000 ± 0%     9.000 ± 0%  -30.77% (p=0.000 n=10)
LogLevels/Warn-16                       13.000 ± 0%     9.000 ± 0%  -30.77% (p=0.000 n=10)
LogLevels/Error-16                      13.000 ± 0%     9.000 ± 0%  -30.77% (p=0.000 n=10)
DisabledLogs-16                          0.000 ± 0%     0.000 ± 0%        ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16             11.000 ± 0%     6.000 ± 0%  -45.45% (p=0.000 n=10)
WithAttrsChaining/Depth3-16             11.000 ± 0%     6.000 ± 0%  -45.45% (p=0.000 n=10)
WithAttrsChaining/Depth5-16             11.000 ± 0%     6.000 ± 0%  -45.45% (p=0.000 n=10)
WithAttrsChaining/Depth10-16            11.000 ± 0%     6.000 ± 0%  -45.45% (p=0.000 n=10)
WithAttrsChaining/Depth20-16            11.000 ± 0%     6.000 ± 0%  -45.45% (p=0.000 n=10)
WithGroupNesting/Depth1-16              12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
WithGroupNesting/Depth3-16              12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
WithGroupNesting/Depth5-16              12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
WithGroupNesting/Depth10-16             12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
MixedWithAttrsAndGroups-16               17.00 ± 0%     12.00 ± 0%  -29.41% (p=0.000 n=10)
AttributeTypes/Strings-16                15.00 ± 0%     10.00 ± 0%  -33.33% (p=0.000 n=10)
AttributeTypes/Ints-16                   18.00 ± 0%     13.00 ± 0%  -27.78% (p=0.000 n=10)
AttributeTypes/Mixed-16                  23.00 ± 0%     18.00 ± 0%  -21.74% (p=0.000 n=10)
AttributeTypes/LargeStrings-16           15.00 ± 0%     10.00 ± 0%  -33.33% (p=0.000 n=10)
AttributeTypes/GroupAttr-16              22.00 ± 0%     17.00 ± 0%  -22.73% (p=0.000 n=10)
AttributeTypes/NestedGroups-16           29.00 ± 0%     24.00 ± 0%  -17.24% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16             16.00 ± 0%     11.00 ± 0%  -31.25% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16             16.00 ± 0%     11.00 ± 0%  -31.25% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16             16.00 ± 0%     11.00 ± 0%  -31.25% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16             16.00 ± 0%     10.00 ± 0%  -37.50% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16            15.00 ± 0%     10.00 ± 0%  -33.33% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16            22.00 ± 0%     17.00 ± 0%  -22.73% (p=0.000 n=10)
HandleOnly/Preformatted0-16              9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
HandleOnly/Preformatted5-16              9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
HandleOnly/Preformatted20-16             9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16    12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16      12.000 ± 0%     7.000 ± 0%  -41.67% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16     1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16    1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16      1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16     1.000 ± 0%     1.000 ± 0%        ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                       9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
CallerCache/NoPC-16                      4.000 ± 0%     4.000 ± 0%        ~ (p=1.000 n=10) ¹
CallerCacheSites-16                      9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
LevelSelection/Debug-16                  9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
LevelSelection/Info-16                   9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
LevelSelection/Warn-16                   9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
LevelSelection/Error-16                  9.000 ± 0%     4.000 ± 0%  -55.56% (p=0.000 n=10)
geomean                                             ²               -35.50%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
