### PR TITLE
perf(handler): only resolve LogValuer attrs, add fastpaths

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -93,7 +93,8 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// - 2 for message (key + value)
 	// - len(h.preformatted) exact items (pre-flattened, no expansion)
 	// - 2 * record.NumAttrs() for record attrs, +50% buffer for group expansion
-	capacity := 8 + len(h.preformatted) + (3 * record.NumAttrs())
+	numAttrs := record.NumAttrs()
+	capacity := 8 + len(h.preformatted) + (3 * numAttrs)
 	pairs := make([]any, 0, capacity)
 
 	// Append the level directly as the first pair. Matches how the log
@@ -134,10 +135,13 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 	// WithAttrs() call.
 	pairs = append(pairs, h.preformatted...)
 
-	record.Attrs(func(a slog.Attr) bool {
-		pairs = appendPair(pairs, h.group, a)
-		return true
-	})
+	// Skip the Attrs() call entirely when there are no attrs.
+	if numAttrs > 0 {
+		record.Attrs(func(a slog.Attr) bool {
+			pairs = appendPair(pairs, h.group, a)
+			return true
+		})
+	}
 
 	return h.logger.Log(pairs...)
 }
@@ -145,6 +149,11 @@ func (h *GoKitHandler) Handle(_ context.Context, record slog.Record) error {
 // WithAttrs formats the provided attributes and caches them in the handler to
 // attach to all future log calls. It implements slog.Handler.
 func (h *GoKitHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	// No attrs, return it untouched. 
+	if len(attrs) == 0 {
+		return h
+	}
+
 	// Make a defensive copy of preformatted attrs to avoid race conditions
 	// when multiple goroutines call WithAttrs concurrently on the same handler.
 	// Attrs are pre-flattened to []any key-value pairs here so that Handle()
@@ -188,6 +197,14 @@ func (h *GoKitHandler) WithGroup(name string) slog.Handler {
 }
 
 func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
+	// Resolve LogValuers before the kind switch so value that resolves to
+	// a group is expanded into individual pairs. Aligns with how the
+	// stdlib handlers resolve before expanding, and also avoids the
+	// defer/recover that `Resolve()` incurs.
+	if attr.Value.Kind() == slog.KindLogValuer {
+		attr.Value = attr.Value.Resolve()
+	}
+
 	if attr.Equal(slog.Attr{}) {
 		return pairs
 	}
@@ -220,7 +237,7 @@ func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
 			key = groupPrefix + "." + key
 		}
 
-		pairs = append(pairs, key, attr.Value.Resolve())
+		pairs = append(pairs, key, attr.Value)
 	}
 
 	return pairs

--- a/handler_test.go
+++ b/handler_test.go
@@ -445,6 +445,62 @@ func TestCallerCache(t *testing.T) {
 	}
 }
 
+// stringValuer is a LogValuer that resolves to a plain string value.
+type stringValuer struct{ s string }
+
+func (v stringValuer) LogValue() slog.Value { return slog.StringValue(v.s) }
+
+// groupValuer is a LogValuer that resolves to a group, the case where
+// resolve-then-expand order is observable: stdlib handlers expand the
+// resolved group into individual keys rather than emitting one value.
+type groupValuer struct{}
+
+func (groupValuer) LogValue() slog.Value {
+	return slog.GroupValue(slog.String("name", "gopher"), slog.Int("age", 42))
+}
+
+// TestLogValuerResolution verifies that LogValuer attrs are resolved before
+// being emitted, and that a LogValuer resolving to a group is expanded into
+// individual dotted keys exactly like a literal group attr, matching the
+// resolve-then-expand order of the stdlib handlers.
+func TestLogValuerResolution(t *testing.T) {
+	t.Run("resolves to scalar", func(t *testing.T) {
+		var buf bytes.Buffer
+		slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil))
+
+		slogger.Info("hello", "who", stringValuer{s: "gopher"})
+		require.Contains(t, buf.String(), "who=gopher")
+	})
+	t.Run("resolves to group", func(t *testing.T) {
+		var buf bytes.Buffer
+		slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil))
+
+		slogger.Info("hello", "req", groupValuer{})
+		require.Contains(t, buf.String(), "req.name=gopher")
+		require.Contains(t, buf.String(), "req.age=42")
+	})
+	t.Run("resolves to group under WithGroup prefix", func(t *testing.T) {
+		var buf bytes.Buffer
+		slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil)).WithGroup("outer")
+
+		slogger.Info("hello", "req", groupValuer{})
+		require.Contains(t, buf.String(), "outer.req.name=gopher")
+		require.Contains(t, buf.String(), "outer.req.age=42")
+	})
+	t.Run("resolves through WithAttrs", func(t *testing.T) {
+		var buf bytes.Buffer
+		slogger := slog.New(slgk.NewGoKitHandler(log.NewLogfmtLogger(&buf), nil).WithAttrs([]slog.Attr{
+			slog.Any("who", stringValuer{s: "gopher"}),
+			slog.Any("req", groupValuer{}),
+		}))
+
+		slogger.Info("hello")
+		require.Contains(t, buf.String(), "who=gopher")
+		require.Contains(t, buf.String(), "req.name=gopher")
+		require.Contains(t, buf.String(), "req.age=42")
+	})
+}
+
 // TestConcurrentHandle drives Handle() concurrently through a single handler
 // from multiple call sites. Under -race this covers the caller cache's
 // concurrent paths: goroutines racing to first-resolve the same PC and


### PR DESCRIPTION
Using `Resolve()` on values adds a defer/recover, which is just overhead
for values that don't need to be resolved. Only resolve `KindLogValuer`,
scope penalty so only valuers pay for it. This also fixes behavior
deviations from upstream slog usage in the stdlib that resolve first and
then expand into individual keys.

testing/slogtest has no LogValuer-to-group case, so the new
TestLogValuerResolution covers resolution to scalars, to groups (bare,
under a WithGroup prefix, and via WithAttrs preformatting).

Also adds a fast path to directly return the handler in `WithAttrs()`
when the input `attrs` slice is empty, as well as a fast path to skip
the `record.Attrs()` closure capture when there are no attrs. When it
ran unconditionally, it cost the closure allocation, plus boxing the
value to append onto the pairs. Skipping it helps to optimize common log
patterns like `logger.Info("foo")` that have no attrs.

benchmarks:

```
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit/benchmarks
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │   head.txt    │          attr-fastpaths.txt          │
                                      │    sec/op     │    sec/op     vs base                │
BasicLog/NoAttrs-16                      976.8n ±  2%   824.9n ±  4%  -15.55% (p=0.000 n=10)
BasicLog/2Attrs-16                       1.343µ ±  2%   1.189µ ±  5%  -11.50% (p=0.000 n=10)
BasicLog/5Attrs-16                       1.858µ ±  3%   1.753µ ± 10%        ~ (p=0.123 n=10)
BasicLog/10Attrs-16                      2.713µ ±  3%   2.447µ ±  5%   -9.80% (p=0.000 n=10)
BasicLog/20Attrs-16                      4.348µ ±  2%   3.743µ ± 12%  -13.93% (p=0.000 n=10)
LogLevels/Debug-16                       1.436µ ±  5%   1.246µ ±  5%  -13.20% (p=0.000 n=10)
LogLevels/Info-16                        1.461µ ±  4%   1.258µ ±  1%  -13.83% (p=0.000 n=10)
LogLevels/Warn-16                        1.419µ ±  2%   1.266µ ±  3%  -10.82% (p=0.000 n=10)
LogLevels/Error-16                       1.425µ ±  3%   1.270µ ±  2%  -10.88% (p=0.000 n=10)
DisabledLogs-16                          6.226n ±  9%   5.939n ±  4%   -4.61% (p=0.023 n=10)
WithAttrsChaining/Depth1-16              1.253µ ±  1%   1.120µ ±  3%  -10.61% (p=0.000 n=10)
WithAttrsChaining/Depth3-16              1.443µ ±  2%   1.252µ ±  3%  -13.27% (p=0.000 n=10)
WithAttrsChaining/Depth5-16              1.597µ ±  3%   1.466µ ±  5%   -8.26% (p=0.000 n=10)
WithAttrsChaining/Depth10-16             1.965µ ±  4%   1.793µ ±  2%   -8.76% (p=0.000 n=10)
WithAttrsChaining/Depth20-16             2.721µ ±  3%   2.480µ ±  3%   -8.86% (p=0.000 n=10)
WithGroupNesting/Depth1-16               1.220µ ±  3%   1.113µ ±  3%   -8.81% (p=0.000 n=10)
WithGroupNesting/Depth3-16               1.282µ ±  2%   1.148µ ±  2%  -10.46% (p=0.000 n=10)
WithGroupNesting/Depth5-16               1.323µ ±  3%   1.174µ ±  7%  -11.23% (p=0.000 n=10)
WithGroupNesting/Depth10-16              1.439µ ±  3%   1.264µ ±  2%  -12.10% (p=0.000 n=10)
MixedWithAttrsAndGroups-16               1.942µ ±  5%   1.736µ ±  4%  -10.61% (p=0.000 n=10)
AttributeTypes/Strings-16                1.435µ ±  2%   1.293µ ±  2%   -9.93% (p=0.000 n=10)
AttributeTypes/Ints-16                   1.576µ ±  3%   1.452µ ±  2%   -7.84% (p=0.000 n=10)
AttributeTypes/Mixed-16                  1.896µ ±  2%   1.744µ ±  3%   -8.04% (p=0.000 n=10)
AttributeTypes/LargeStrings-16           6.215µ ±  2%   3.238µ ±  2%  -47.90% (p=0.000 n=10)
AttributeTypes/GroupAttr-16              3.161µ ±  2%   1.649µ ±  2%  -47.82% (p=0.000 n=10)
AttributeTypes/NestedGroups-16           4.053µ ±  2%   2.050µ ±  4%  -49.43% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16             616.7n ±  2%   343.0n ±  6%  -44.38% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16             635.0n ±  2%   366.3n ±  4%  -42.31% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16             644.9n ±  5%   374.8n ±  3%  -41.87% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16             597.1n ±  6%   384.2n ±  2%  -35.66% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16            406.2n ±  2%   381.3n ±  2%   -6.13% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16            541.8n ±  1%   500.4n ±  2%   -7.63% (p=0.000 n=10)
HandleOnly/Preformatted0-16             1014.5n ±  2%   900.4n ± 12%  -11.24% (p=0.003 n=10)
HandleOnly/Preformatted5-16              1.408µ ±  3%   1.275µ ±  3%   -9.48% (p=0.000 n=10)
HandleOnly/Preformatted20-16             2.506µ ±  3%   2.289µ ±  7%   -8.70% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16     1.276µ ±  3%   1.171µ ±  6%   -8.23% (p=0.002 n=10)
EnabledCheck/Enabled_InfoAtInfo-16       1.285µ ±  1%   1.153µ ±  4%  -10.27% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16     31.70n ±  2%   28.80n ±  5%   -9.12% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtError-16    31.70n ±  2%   28.66n ±  4%   -9.59% (p=0.000 n=10)
EnabledCheck/Disabled_InfoAtWarn-16      31.71n ±  2%   28.30n ±  9%  -10.77% (p=0.000 n=10)
EnabledCheck/Disabled_WarnAtError-16     30.95n ±  2%   29.54n ± 14%        ~ (p=0.105 n=10)
CallerCache/Hit-16                       740.7n ±  1%   666.8n ±  8%   -9.98% (p=0.002 n=10)
CallerCache/NoPC-16                      636.4n ±  2%   569.6n ±  4%  -10.50% (p=0.000 n=10)
CallerCacheSites-16                      1.163µ ±  2%   1.033µ ±  4%  -11.22% (p=0.000 n=10)
LevelSelection/Debug-16                  810.2n ± 14%   812.3n ±  2%        ~ (p=0.739 n=10)
LevelSelection/Info-16                   797.6n ±  2%   820.9n ±  2%   +2.91% (p=0.000 n=10)
LevelSelection/Warn-16                   790.9n ±  1%   837.8n ±  7%   +5.93% (p=0.000 n=10)
LevelSelection/Error-16                  790.9n ±  1%   822.0n ±  4%   +3.94% (p=0.000 n=10)
geomean                                  865.6n         735.1n        -15.08%

                                      │    head.txt    │          attr-fastpaths.txt           │
                                      │      B/op      │     B/op      vs base                 │
BasicLog/NoAttrs-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/2Attrs-16                        392.0 ± 0%       392.0 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/5Attrs-16                        673.0 ± 0%       673.0 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/10Attrs-16                     1.307Ki ± 0%     1.307Ki ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/20Attrs-16                     2.621Ki ± 0%     2.621Ki ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Debug-16                        456.0 ± 0%       456.0 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Info-16                         456.0 ± 0%       456.0 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Warn-16                         456.0 ± 0%       456.0 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Error-16                        456.0 ± 0%       456.0 ± 0%       ~ (p=1.000 n=10) ¹
DisabledLogs-16                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16               336.0 ± 0%       336.0 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth3-16               416.0 ± 0%       416.0 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth5-16               480.0 ± 0%       480.0 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth10-16              641.0 ± 0%       641.0 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth20-16            1.001Ki ± 0%     1.001Ki ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth1-16                320.0 ± 0%       320.0 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth3-16                328.0 ± 0%       328.0 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth5-16                352.0 ± 0%       352.0 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth10-16               384.0 ± 0%       384.0 ± 0%       ~ (p=1.000 n=10) ¹
MixedWithAttrsAndGroups-16                568.0 ± 0%       568.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Strings-16                 496.0 ± 0%       496.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Ints-16                    520.0 ± 0%       520.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Mixed-16                   616.0 ± 0%       616.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/LargeStrings-16            424.0 ± 0%       424.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/GroupAttr-16               984.0 ± 0%       984.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/NestedGroups-16          1.251Ki ± 0%     1.251Ki ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale1x-16              449.0 ± 0%       449.0 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale2x-16              449.0 ± 0%       449.0 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale4x-16              449.0 ± 0%       449.0 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale8x-16              449.0 ± 0%       449.0 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale16x-16             449.0 ± 0%       449.0 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentWithAttrsThenLog-16             761.0 ± 0%       762.0 ± 0%  +0.13% (p=0.001 n=10)
HandleOnly/Preformatted0-16               216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted5-16               376.0 ± 0%       376.0 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted20-16              985.0 ± 0%       985.0 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_DebugAtDebug-16      336.0 ± 0%       336.0 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_InfoAtInfo-16        336.0 ± 0%       336.0 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtInfo-16      32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16     32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16       32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16      32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                        216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/NoPC-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
CallerCacheSites-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                   216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Info-16                    216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Warn-16                    216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Error-16                   216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                              ²                 +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │   head.txt   │         attr-fastpaths.txt          │
                                      │  allocs/op   │ allocs/op   vs base                 │
BasicLog/NoAttrs-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/2Attrs-16                      8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/5Attrs-16                      14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/10Attrs-16                     25.00 ± 0%     25.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/20Attrs-16                     45.00 ± 0%     45.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Debug-16                      9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Info-16                       9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Warn-16                       9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Error-16                      9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
DisabledLogs-16                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth3-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth5-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth10-16            6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth20-16            6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth1-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth3-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth5-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth10-16             7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
MixedWithAttrsAndGroups-16              12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Strings-16               10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Ints-16                  13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Mixed-16                 18.00 ± 0%     18.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/LargeStrings-16          10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/GroupAttr-16             17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/NestedGroups-16          24.00 ± 0%     24.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale1x-16            11.00 ± 0%     11.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale2x-16            11.00 ± 0%     11.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale4x-16            11.00 ± 9%     11.00 ± 0%       ~ (p=0.474 n=10)
ConcurrentLogging/Scale8x-16            10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale16x-16           10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentWithAttrsThenLog-16           17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted0-16             4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted5-16             4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted20-16            4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_DebugAtDebug-16    7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_InfoAtInfo-16      7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtInfo-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                      4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/NoPC-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCacheSites-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                 4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Info-16                  4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Warn-16                  4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Error-16                 4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
