### PR TITLE
perf(handler): append string attr values unboxed

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -237,7 +237,14 @@ func appendPair(pairs []any, groupPrefix string, attr slog.Attr) []any {
 			key = groupPrefix + "." + key
 		}
 
-		pairs = append(pairs, key, attr.Value)
+		// Append string values as raw strings rather than boxed
+		// slog.Values, lean on string path optimizations in slog and
+		// go-kit/log.
+		if attr.Value.Kind() == slog.KindString {
+			pairs = append(pairs, key, attr.Value.String())
+		} else {
+			pairs = append(pairs, key, attr.Value)
+		}
 	}
 
 	return pairs


### PR DESCRIPTION
Both slog and go-kit/log include some optimizations for strings, which
makes sense considering those are the most common log value type.

In slog, `Value.String()` returns the string directly via unsafe.String.
Boxing the string to any instead of the slog.Value results in a smaller
boxed value.

In go-kit/log, both logfmt and JSON have fast path handling for strings
that avoid extra processing and a defer/recover.

Benchmarks:

```
goos: linux
goarch: amd64
pkg: github.com/tjhop/slog-gokit/benchmarks
cpu: 11th Gen Intel(R) Core(TM) i7-11850H @ 2.50GHz
                                      │  main.txt   │   perf-string-value-fastpath.txt   │
                                      │   sec/op    │   sec/op     vs base               │
BasicLog/NoAttrs-16                     1.045µ ± 6%   1.048µ ± 9%       ~ (p=0.725 n=10)
BasicLog/2Attrs-16                      1.454µ ± 2%   1.407µ ± 4%  -3.27% (p=0.009 n=10)
BasicLog/5Attrs-16                      2.089µ ± 4%   2.006µ ± 2%  -3.97% (p=0.000 n=10)
BasicLog/10Attrs-16                     3.032µ ± 8%   2.860µ ± 1%  -5.67% (p=0.000 n=10)
BasicLog/20Attrs-16                     4.928µ ± 2%   4.698µ ± 2%  -4.67% (p=0.000 n=10)
LogLevels/Debug-16                      1.509µ ± 2%   1.505µ ± 7%       ~ (p=0.698 n=10)
LogLevels/Info-16                       1.538µ ± 2%   1.500µ ± 4%  -2.47% (p=0.024 n=10)
LogLevels/Warn-16                       1.521µ ± 5%   1.489µ ± 5%  -2.14% (p=0.000 n=10)
LogLevels/Error-16                      1.517µ ± 2%   1.484µ ± 2%  -2.18% (p=0.002 n=10)
DisabledLogs-16                         6.133n ± 2%   6.176n ± 1%       ~ (p=0.971 n=10)
WithAttrsChaining/Depth1-16             1.347µ ± 1%   1.324µ ± 4%  -1.67% (p=0.008 n=10)
WithAttrsChaining/Depth3-16             1.597µ ± 3%   1.555µ ± 7%       ~ (p=0.072 n=10)
WithAttrsChaining/Depth5-16             1.812µ ± 4%   1.695µ ± 2%  -6.46% (p=0.000 n=10)
WithAttrsChaining/Depth10-16            2.218µ ± 4%   2.075µ ± 3%  -6.47% (p=0.000 n=10)
WithAttrsChaining/Depth20-16            3.058µ ± 2%   2.828µ ± 2%  -7.52% (p=0.000 n=10)
WithGroupNesting/Depth1-16              1.317µ ± 1%   1.309µ ± 7%       ~ (p=0.566 n=10)
WithGroupNesting/Depth3-16              1.380µ ± 2%   1.355µ ± 9%       ~ (p=0.255 n=10)
WithGroupNesting/Depth5-16              1.423µ ± 7%   1.402µ ± 3%  -1.44% (p=0.019 n=10)
WithGroupNesting/Depth10-16             1.530µ ± 2%   1.523µ ± 1%       ~ (p=0.579 n=10)
MixedWithAttrsAndGroups-16              2.182µ ± 4%   2.108µ ± 2%  -3.39% (p=0.001 n=10)
AttributeTypes/Strings-16               1.629µ ± 1%   1.538µ ± 9%  -5.56% (p=0.022 n=10)
AttributeTypes/Ints-16                  1.781µ ± 6%   1.770µ ± 2%       ~ (p=0.148 n=10)
AttributeTypes/Mixed-16                 2.126µ ± 2%   2.100µ ± 9%       ~ (p=0.138 n=10)
AttributeTypes/LargeStrings-16          3.980µ ± 3%   3.921µ ± 2%       ~ (p=0.063 n=10)
AttributeTypes/GroupAttr-16             2.038µ ± 2%   2.022µ ± 2%       ~ (p=0.172 n=10)
AttributeTypes/NestedGroups-16          2.627µ ± 1%   2.581µ ± 4%  -1.77% (p=0.018 n=10)
ConcurrentLogging/Scale1x-16            453.5n ± 2%   444.9n ± 3%       ~ (p=0.101 n=10)
ConcurrentLogging/Scale2x-16            474.3n ± 6%   462.0n ± 6%       ~ (p=0.086 n=10)
ConcurrentLogging/Scale4x-16            488.5n ± 6%   477.3n ± 3%  -2.29% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16            501.2n ± 1%   489.9n ± 2%  -2.24% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16           504.1n ± 1%   494.0n ± 3%  -1.99% (p=0.002 n=10)
ConcurrentWithAttrsThenLog-16           692.5n ± 1%   677.6n ± 4%  -2.17% (p=0.018 n=10)
HandleOnly/Preformatted0-16             1.080µ ± 2%   1.066µ ± 2%       ~ (p=0.108 n=10)
HandleOnly/Preformatted5-16             1.577µ ± 2%   1.505µ ± 2%  -4.60% (p=0.000 n=10)
HandleOnly/Preformatted20-16            2.830µ ± 2%   2.613µ ± 3%  -7.65% (p=0.000 n=10)
EnabledCheck/Enabled_DebugAtDebug-16    1.386µ ± 2%   1.355µ ± 5%       ~ (p=0.101 n=10)
EnabledCheck/Enabled_InfoAtInfo-16      1.389µ ± 1%   1.370µ ± 6%       ~ (p=0.127 n=10)
EnabledCheck/Disabled_DebugAtInfo-16    37.88n ± 2%   37.84n ± 2%       ~ (p=0.616 n=10)
EnabledCheck/Disabled_DebugAtError-16   38.81n ± 3%   37.80n ± 4%       ~ (p=0.165 n=10)
EnabledCheck/Disabled_InfoAtWarn-16     37.60n ± 2%   37.84n ± 2%       ~ (p=0.447 n=10)
EnabledCheck/Disabled_WarnAtError-16    37.95n ± 2%   38.05n ± 2%       ~ (p=0.796 n=10)
CallerCache/Hit-16                      806.9n ± 2%   806.6n ± 2%       ~ (p=0.579 n=10)
CallerCache/NoPC-16                     702.1n ± 1%   704.5n ± 2%       ~ (p=0.529 n=10)
CallerCacheSites-16                     1.275µ ± 5%   1.261µ ± 2%       ~ (p=0.271 n=10)
LevelSelection/Debug-16                 1.020µ ± 5%   1.010µ ± 7%       ~ (p=0.724 n=10)
LevelSelection/Info-16                  1.010µ ± 3%   1.009µ ± 1%       ~ (p=0.541 n=10)
LevelSelection/Warn-16                  1.011µ ± 4%   1.009µ ± 6%       ~ (p=0.447 n=10)
LevelSelection/Error-16                 1.027µ ± 2%   1.001µ ± 3%  -2.58% (p=0.005 n=10)
geomean                                 913.3n        893.3n       -2.20%

                                      │    main.txt    │    perf-string-value-fastpath.txt     │
                                      │      B/op      │     B/op      vs base                 │
BasicLog/NoAttrs-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/2Attrs-16                        392.0 ± 0%       376.0 ± 0%  -4.08% (p=0.000 n=10)
BasicLog/5Attrs-16                        673.0 ± 0%       632.0 ± 0%  -6.09% (p=0.000 n=10)
BasicLog/10Attrs-16                     1.307Ki ± 0%     1.228Ki ± 0%  -6.05% (p=0.000 n=10)
BasicLog/20Attrs-16                     2.621Ki ± 0%     2.465Ki ± 0%  -5.96% (p=0.000 n=10)
LogLevels/Debug-16                        456.0 ± 0%       440.0 ± 0%  -3.51% (p=0.000 n=10)
LogLevels/Info-16                         456.0 ± 0%       440.0 ± 0%  -3.51% (p=0.000 n=10)
LogLevels/Warn-16                         456.0 ± 0%       440.0 ± 0%  -3.51% (p=0.000 n=10)
LogLevels/Error-16                        456.0 ± 0%       440.0 ± 0%  -3.51% (p=0.000 n=10)
DisabledLogs-16                           0.000 ± 0%       0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16               336.0 ± 0%       328.0 ± 0%  -2.38% (p=0.000 n=10)
WithAttrsChaining/Depth3-16               416.0 ± 0%       408.0 ± 0%  -1.92% (p=0.000 n=10)
WithAttrsChaining/Depth5-16               480.0 ± 0%       472.0 ± 0%  -1.67% (p=0.000 n=10)
WithAttrsChaining/Depth10-16              641.0 ± 0%       633.0 ± 0%  -1.25% (p=0.000 n=10)
WithAttrsChaining/Depth20-16             1025.0 ± 0%      1017.0 ± 0%  -0.78% (p=0.000 n=10)
WithGroupNesting/Depth1-16                320.0 ± 0%       312.0 ± 0%  -2.50% (p=0.000 n=10)
WithGroupNesting/Depth3-16                328.0 ± 0%       320.0 ± 0%  -2.44% (p=0.000 n=10)
WithGroupNesting/Depth5-16                352.0 ± 0%       344.0 ± 0%  -2.27% (p=0.000 n=10)
WithGroupNesting/Depth10-16               384.0 ± 0%       376.0 ± 0%  -2.08% (p=0.000 n=10)
MixedWithAttrsAndGroups-16                568.0 ± 0%       560.0 ± 0%  -1.41% (p=0.000 n=10)
AttributeTypes/Strings-16                 496.0 ± 0%       472.0 ± 0%  -4.84% (p=0.000 n=10)
AttributeTypes/Ints-16                    520.0 ± 0%       520.0 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Mixed-16                   616.0 ± 0%       608.0 ± 0%  -1.30% (p=0.000 n=10)
AttributeTypes/LargeStrings-16            424.0 ± 0%       408.0 ± 0%  -3.77% (p=0.000 n=10)
AttributeTypes/GroupAttr-16               984.0 ± 0%       976.0 ± 0%  -0.81% (p=0.000 n=10)
AttributeTypes/NestedGroups-16          1.251Ki ± 0%     1.235Ki ± 0%  -1.25% (p=0.000 n=10)
ConcurrentLogging/Scale1x-16              449.0 ± 0%       441.0 ± 0%  -1.78% (p=0.000 n=10)
ConcurrentLogging/Scale2x-16              449.0 ± 0%       441.0 ± 0%  -1.78% (p=0.000 n=10)
ConcurrentLogging/Scale4x-16              449.0 ± 0%       441.0 ± 0%  -1.78% (p=0.000 n=10)
ConcurrentLogging/Scale8x-16              449.0 ± 0%       441.0 ± 0%  -1.78% (p=0.000 n=10)
ConcurrentLogging/Scale16x-16             449.0 ± 0%       441.0 ± 0%  -1.78% (p=0.000 n=10)
ConcurrentWithAttrsThenLog-16             762.0 ± 0%       754.0 ± 0%  -1.05% (p=0.000 n=10)
HandleOnly/Preformatted0-16               216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted5-16               376.0 ± 0%       376.0 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted20-16              985.0 ± 0%       985.0 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_DebugAtDebug-16      336.0 ± 0%       328.0 ± 0%  -2.38% (p=0.000 n=10)
EnabledCheck/Enabled_InfoAtInfo-16        336.0 ± 0%       328.0 ± 0%  -2.38% (p=0.000 n=10)
EnabledCheck/Disabled_DebugAtInfo-16      32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16     32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16       32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16      32.00 ± 0%       32.00 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                        216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/NoPC-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
CallerCacheSites-16                       216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                   216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Info-16                    216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Warn-16                    216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Error-16                   216.0 ± 0%       216.0 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                              ²                 -1.72%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                                      │   main.txt   │   perf-string-value-fastpath.txt    │
                                      │  allocs/op   │ allocs/op   vs base                 │
BasicLog/NoAttrs-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/2Attrs-16                      8.000 ± 0%     8.000 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/5Attrs-16                      14.00 ± 0%     14.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/10Attrs-16                     25.00 ± 0%     25.00 ± 0%       ~ (p=1.000 n=10) ¹
BasicLog/20Attrs-16                     45.00 ± 0%     45.00 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Debug-16                      9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Info-16                       9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Warn-16                       9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
LogLevels/Error-16                      9.000 ± 0%     9.000 ± 0%       ~ (p=1.000 n=10) ¹
DisabledLogs-16                         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth1-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth3-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth5-16             6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth10-16            6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithAttrsChaining/Depth20-16            6.000 ± 0%     6.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth1-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth3-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth5-16              7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
WithGroupNesting/Depth10-16             7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
MixedWithAttrsAndGroups-16              12.00 ± 0%     12.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Strings-16               10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Ints-16                  13.00 ± 0%     13.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/Mixed-16                 18.00 ± 0%     18.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/LargeStrings-16          10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/GroupAttr-16             17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
AttributeTypes/NestedGroups-16          24.00 ± 0%     24.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale1x-16            11.00 ± 0%     11.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale2x-16            11.00 ± 0%     11.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale4x-16            11.00 ± 0%     11.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale8x-16            10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentLogging/Scale16x-16           10.00 ± 0%     10.00 ± 0%       ~ (p=1.000 n=10) ¹
ConcurrentWithAttrsThenLog-16           17.00 ± 0%     17.00 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted0-16             4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted5-16             4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
HandleOnly/Preformatted20-16            4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_DebugAtDebug-16    7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Enabled_InfoAtInfo-16      7.000 ± 0%     7.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtInfo-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_DebugAtError-16   1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_InfoAtWarn-16     1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
EnabledCheck/Disabled_WarnAtError-16    1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/Hit-16                      4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCache/NoPC-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
CallerCacheSites-16                     4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Debug-16                 4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Info-16                  4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Warn-16                  4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
LevelSelection/Error-16                 4.000 ± 0%     4.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                                            ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
